### PR TITLE
Add probabilistic transform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ references:
       name: Build by g++.
       command: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug ..
+        # decrease the debug level to reduce g++ memory usage
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-g0" ..
         make
         make install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,20 +36,20 @@ configure_file(
 # Compiler Flags
 # --------------
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -Wall -pedantic -pipe")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3 -fno-inline -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -Ofast")
+set(CMAKE_CXX_FLAGS "-std=c++1z -Wall -pedantic ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 ${CMAKE_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 ${CMAKE_CXX_FLAGS_RELEASE}")
 
 # ----------------------
 # Shorter Error Messages
 # ----------------------
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wfatal-errors")
+  set(CMAKE_CXX_FLAGS "-Wfatal-errors ${CMAKE_CXX_FLAGS}")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # GCC truncates multiline errors with -Wfatal-errors
   # using -fmax-erorrs instead
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmax-errors=2")
+  set(CMAKE_CXX_FLAGS "-fmax-errors=2 ${CMAKE_CXX_FLAGS}")
 endif()
 
 # ---------------------

--- a/include/cxtream/core/groups.hpp
+++ b/include/cxtream/core/groups.hpp
@@ -10,7 +10,7 @@
 #ifndef CXTREAM_CORE_GROUPS_HPP
 #define CXTREAM_CORE_GROUPS_HPP
 
-#include <cxtream/core/dataframe.hpp>
+#include <cxtream/core/utility/random.hpp>
 
 #include <range/v3/action/insert.hpp>
 #include <range/v3/action/shuffle.hpp>
@@ -24,7 +24,6 @@
 #include <range/v3/view/repeat_n.hpp>
 #include <range/v3/view/take.hpp>
 
-#include <random>
 #include <vector>
 
 namespace cxtream {
@@ -44,7 +43,7 @@ namespace cxtream {
 ///              the sum of ratios has to be positive.
 template<typename Prng = std::mt19937>
 std::vector<std::size_t> generate_groups(std::size_t size, std::vector<double> ratio,
-                                         Prng&& gen = Prng{std::random_device{}()})
+                                         Prng&& gen = utility::random_generator)
 {
     namespace view = ranges::view;
 
@@ -100,7 +99,7 @@ std::vector<std::vector<std::size_t>>
 generate_groups(std::size_t n, std::size_t size,
                 const std::vector<double>& volatile_ratio,
                 const std::vector<double>& fixed_ratio,
-                Prng&& gen = Prng{std::random_device{}()})
+                Prng&& gen = utility::random_generator)
 {
     namespace view = ranges::view;
 

--- a/include/cxtream/core/stream/transform.hpp
+++ b/include/cxtream/core/stream/transform.hpp
@@ -186,7 +186,7 @@ namespace detail {
 /// Example:
 /// \code
 ///     CXTREAM_DEFINE_COLUMN(dogs, int)
-///     std::vector<std::tuple<int>> data = {3, 1, 5, 7};
+///     std::vector<int> data = {3, 1, 5, 7};
 ///     auto rng = data
 ///       | create<dogs>()
 ///       // In 50% of the cases, the number of dogs increase,

--- a/include/cxtream/core/utility/random.hpp
+++ b/include/cxtream/core/utility/random.hpp
@@ -7,13 +7,16 @@
  *  See the accompanying file LICENSE.txt for the complete license agreement.
  ****************************************************************************/
 
-#ifndef CXTREAM_CORE_UTILITY_HPP
-#define CXTREAM_CORE_UTILITY_HPP
+#ifndef CXTREAM_CORE_UTILITY_RANDOM_HPP
+#define CXTREAM_CORE_UTILITY_RANDOM_HPP
 
-#include <cxtream/core/utility/filesystem.hpp>
-#include <cxtream/core/utility/random.hpp>
-#include <cxtream/core/utility/string.hpp>
-#include <cxtream/core/utility/tuple.hpp>
-#include <cxtream/core/utility/vector.hpp>
+#include <random>
+
+namespace cxtream::utility {
+
+/// Thread local pseudo-random number generator seeded by the std::random_device.
+static thread_local std::mt19937 random_generator{std::random_device{}()};
+
+}  // namespace cxtream::utility
 
 #endif

--- a/include/cxtream/core/utility/tuple.hpp
+++ b/include/cxtream/core/utility/tuple.hpp
@@ -40,6 +40,29 @@ template<typename T, typename... Ts>
 struct variadic_find<T, T, Ts...> : std::integral_constant<std::size_t, 0> {
 };
 
+/// Add a number to all values in std::index_sequence.
+///
+/// Example:
+/// \code
+///     std::is_same<decltype(plus<2>(std::index_sequence<1, 3, 4>{})),
+///                                   std::index_sequence<3, 5, 6>>;
+/// \endcode
+template<std::size_t Value, std::size_t... Is>
+constexpr std::index_sequence<(Value + Is)...> plus(std::index_sequence<Is...>)
+{
+    return {};
+}
+
+/// Make std::index_sequence with the given offset.
+///
+/// Example:
+/// \code
+///     std::is_same<decltype(make_offset_index_sequence<3, 4>()),
+///                           std::index_sequence<3, 4, 5, 6>>;
+/// \endcode
+template <std::size_t Offset, std::size_t N>
+using make_offset_index_sequence = decltype(plus<Offset>(std::make_index_sequence<N>{}));
+
 // tuple_for_each //
 
 namespace detail {

--- a/test/core/common.hpp
+++ b/test/core/common.hpp
@@ -27,6 +27,8 @@ CXTREAM_DEFINE_COLUMN(Int, int)
 CXTREAM_DEFINE_COLUMN(Double, double)
 CXTREAM_DEFINE_COLUMN(Unique, std::unique_ptr<int>)
 CXTREAM_DEFINE_COLUMN(Shared, std::shared_ptr<int>)
+CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
+CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
 
 std::vector<std::tuple<int, std::vector<std::unique_ptr<int>>>> generate_move_only_data()
 {

--- a/test/core/stream/CMakeLists.txt
+++ b/test/core/stream/CMakeLists.txt
@@ -6,12 +6,18 @@ add_boost_test("test.core.stream.create" "create.cpp" "")
 
 add_boost_test("test.core.stream.drop" "drop.cpp" "")
 
-add_boost_test("test.core.stream.filter" "filter.cpp" "")
+add_boost_test("test.core.stream.filter1" "filter1.cpp" "")
+
+add_boost_test("test.core.stream.filter2" "filter2.cpp" "")
 
 add_boost_test("test.core.stream.for_each" "for_each.cpp" "")
 
 add_boost_test("test.core.stream.random_fill" "random_fill.cpp" "")
 
-add_boost_test("test.core.stream.transform" "transform.cpp" "")
+add_boost_test("test.core.stream.transform1" "transform1.cpp" "")
+
+add_boost_test("test.core.stream.transform2" "transform2.cpp" "")
+
+add_boost_test("test.core.stream.transform3" "transform3.cpp" "")
 
 add_boost_test("test.core.stream.unpack" "unpack.cpp" "")

--- a/test/core/stream/filter.hpp
+++ b/test/core/stream/filter.hpp
@@ -1,0 +1,26 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+#ifndef TEST_STREAM_FILTER_HPP
+#define TEST_STREAM_FILTER_HPP
+
+#include "../common.hpp"
+
+#include <cxtream/core/stream/create.hpp>
+#include <cxtream/core/stream/filter.hpp>
+#include <cxtream/core/stream/for_each.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <range/v3/to_container.hpp>
+#include <range/v3/view/move.hpp>
+
+#include <tuple>
+#include <vector>
+
+#endif

--- a/test/core/stream/filter1.cpp
+++ b/test/core/stream/filter1.cpp
@@ -7,21 +7,12 @@
  *  See the accompanying file LICENSE.txt for the complete license agreement.
  ****************************************************************************/
 
+// The tests for stream::filter are split to multiple
+// files to speed up compilation in case of multiple CPUs.
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE filter_test
+#define BOOST_TEST_MODULE filter1_test
 
-#include "../common.hpp"
-
-#include <cxtream/core/stream/create.hpp>
-#include <cxtream/core/stream/filter.hpp>
-#include <cxtream/core/stream/for_each.hpp>
-
-#include <boost/test/unit_test.hpp>
-#include <range/v3/to_container.hpp>
-#include <range/v3/view/move.hpp>
-
-#include <tuple>
-#include <vector>
+#include "filter.hpp"
 
 using namespace cxtream::stream;
 
@@ -177,65 +168,4 @@ BOOST_AUTO_TEST_CASE(test_dim2)
         }, dim<0>)
       | ranges::to_vector;
     BOOST_TEST(i == 2);
-}
-
-BOOST_AUTO_TEST_CASE(test_dim2_partial)
-{
-    CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
-    const std::vector<std::tuple<int, std::vector<int>>> data = {
-      {{3, {1, 5}}, {1, {2, 4}}, {2, {7, 1}}, {6, {3, 5}}}};
-
-    std::size_t i = 0;
-    auto generated = data
-      | create<Int, IntVec>(2)
-      | filter(from<IntVec>, by<IntVec>, [](int v) { return v >= 4; }, dim<2>)
-      | for_each(from<Int, IntVec>, [&i](auto& ints, auto& intvecs) {
-            switch (i++) {
-            case 0: BOOST_TEST(ints    == (std::vector<int>{3, 1}));
-                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{5}, {4}}));
-                    break;
-            case 1: BOOST_TEST(ints    == (std::vector<int>{2, 6}));
-                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{7}, {5}}));
-                    break;
-            }
-        }, dim<0>)
-      | ranges::to_vector;
-    BOOST_TEST(i == 2);
-}
-
-BOOST_AUTO_TEST_CASE(test_dim2_move_only)
-{
-    CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
-    std::vector<std::tuple<UniqueVec>> data;
-    std::vector<std::unique_ptr<int>> v1;
-    std::vector<std::unique_ptr<int>> v2;
-    std::vector<std::unique_ptr<int>> v3;
-    v1.emplace_back(std::make_unique<int>(5));
-    v1.emplace_back(std::make_unique<int>(3));
-    v2.emplace_back(std::make_unique<int>(2));
-    v2.emplace_back(std::make_unique<int>(4));
-    v3.emplace_back(std::make_unique<int>(1));
-    v3.emplace_back(std::make_unique<int>(6));
-    data.emplace_back(std::move(v1));
-    data.emplace_back(std::move(v2));
-    data.emplace_back(std::move(v3));
-
-    std::size_t i = 0;
-    data
-      | ranges::view::move
-      | filter(from<UniqueVec>, by<UniqueVec>, [](auto& ptr) { return *ptr >= 4.; }, dim<2>)
-      | for_each(from<UniqueVec>, [&i](auto& unique_vec) {
-            switch (i++) {
-            BOOST_TEST(unique_vec.size() == 1);
-            BOOST_TEST(unique_vec.at(0).size() == 1);
-            case 0: BOOST_TEST(*(unique_vec.at(0).at(0)) == 5);
-                    break;
-            case 1: BOOST_TEST(*(unique_vec.at(0).at(0)) == 4);
-                    break;
-            case 2: BOOST_TEST(*(unique_vec.at(0).at(0)) == 6);
-                    break;
-            }
-        }, dim<0>)
-      | ranges::to_vector;
-    BOOST_TEST(i == 3);
 }

--- a/test/core/stream/filter2.cpp
+++ b/test/core/stream/filter2.cpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE filter2_test
+
+#include "filter.hpp"
+
+using namespace cxtream::stream;
+
+BOOST_AUTO_TEST_CASE(test_dim2_partial)
+{
+    CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
+    const std::vector<std::tuple<int, std::vector<int>>> data = {
+      {{3, {1, 5}}, {1, {2, 4}}, {2, {7, 1}}, {6, {3, 5}}}};
+
+    std::size_t i = 0;
+    auto generated = data
+      | create<Int, IntVec>(2)
+      | filter(from<IntVec>, by<IntVec>, [](int v) { return v >= 4; }, dim<2>)
+      | for_each(from<Int, IntVec>, [&i](auto& ints, auto& intvecs) {
+            switch (i++) {
+            case 0: BOOST_TEST(ints    == (std::vector<int>{3, 1}));
+                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{5}, {4}}));
+                    break;
+            case 1: BOOST_TEST(ints    == (std::vector<int>{2, 6}));
+                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{7}, {5}}));
+                    break;
+            }
+        }, dim<0>)
+      | ranges::to_vector;
+    BOOST_TEST(i == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_dim2_move_only)
+{
+    std::vector<std::tuple<UniqueVec>> data;
+    std::vector<std::unique_ptr<int>> v1;
+    std::vector<std::unique_ptr<int>> v2;
+    std::vector<std::unique_ptr<int>> v3;
+    v1.emplace_back(std::make_unique<int>(5));
+    v1.emplace_back(std::make_unique<int>(3));
+    v2.emplace_back(std::make_unique<int>(2));
+    v2.emplace_back(std::make_unique<int>(4));
+    v3.emplace_back(std::make_unique<int>(1));
+    v3.emplace_back(std::make_unique<int>(6));
+    data.emplace_back(std::move(v1));
+    data.emplace_back(std::move(v2));
+    data.emplace_back(std::move(v3));
+
+    std::size_t i = 0;
+    data
+      | ranges::view::move
+      | filter(from<UniqueVec>, by<UniqueVec>, [](auto& ptr) { return *ptr >= 4.; }, dim<2>)
+      | for_each(from<UniqueVec>, [&i](auto& unique_vec) {
+            switch (i++) {
+            BOOST_TEST(unique_vec.size() == 1);
+            BOOST_TEST(unique_vec.at(0).size() == 1);
+            case 0: BOOST_TEST(*(unique_vec.at(0).at(0)) == 5);
+                    break;
+            case 1: BOOST_TEST(*(unique_vec.at(0).at(0)) == 4);
+                    break;
+            case 2: BOOST_TEST(*(unique_vec.at(0).at(0)) == 6);
+                    break;
+            }
+        }, dim<0>)
+      | ranges::to_vector;
+    BOOST_TEST(i == 3);
+}

--- a/test/core/stream/for_each.cpp
+++ b/test/core/stream/for_each.cpp
@@ -26,8 +26,6 @@
 
 using namespace cxtream::stream;
 
-CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
-
 BOOST_AUTO_TEST_CASE(test_partial_for_each)
 {
     // partial_for_each

--- a/test/core/stream/transform.cpp
+++ b/test/core/stream/transform.cpp
@@ -18,6 +18,7 @@
 #include <cxtream/core/stream/unpack.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include <range/v3/algorithm/count.hpp>
 #include <range/v3/to_container.hpp>
 #include <range/v3/view/indirect.hpp>
 #include <range/v3/view/iota.hpp>
@@ -30,8 +31,20 @@
 
 using namespace cxtream::stream;
 
+// test with a seeded random generator
+std::mt19937 prng{1000003};
+
 CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
 CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
+
+auto unique_vec_to_int_vec()
+{
+    return
+        transform(from<UniqueVec>, to<IntVec>, [](auto&& ptrs) {
+            return ptrs | ranges::view::indirect;
+        }, dim<1>)
+      | drop<UniqueVec>;
+}
 
 BOOST_AUTO_TEST_CASE(test_partial_transform)
 {
@@ -164,10 +177,7 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only)
             return std::make_unique<int>(*ptr + 1);
         }, dim<2>)
       | drop<Int>
-      | transform(from<UniqueVec>, to<IntVec>, [](auto&& ptrs) {
-            return ptrs | ranges::view::indirect;
-        }, dim<1>)
-      | drop<UniqueVec>;
+      | unique_vec_to_int_vec();
 
     std::vector<std::vector<std::vector<int>>> generated = unpack(rng, from<IntVec>, dim<0>);
     std::vector<std::vector<std::vector<int>>> desired = {{{2, 5}, {9, 3}}, {{3, 6}}};
@@ -186,10 +196,7 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only_mutable)
             return std::make_unique<int>(i++);
         }, dim<2>)
       | drop<Int>
-      | transform(from<UniqueVec>, to<IntVec>, [](auto&& ptrs) {
-            return ptrs | ranges::view::indirect;
-        }, dim<1>)
-      | drop<UniqueVec>;
+      | unique_vec_to_int_vec();
 
     std::vector<std::vector<std::vector<int>>> generated = unpack(rng, from<IntVec>, dim<0>);
     std::vector<std::vector<std::vector<int>>> desired = {{{4, 5}, {4, 5}}, {{4, 5}}};
@@ -197,4 +204,75 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only_mutable)
 #else
     BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
 #endif
+}
+
+BOOST_AUTO_TEST_CASE(test_probabilistic_simple)
+{
+    CXTREAM_DEFINE_COLUMN(dogs, int)
+    std::vector<int> data = {3, 1, 5, 7, 2, 13};
+    auto rng = data
+      | create<dogs>()
+      | transform(from<dogs>, to<dogs>, 1.0, [](int dog) { return 1; }, prng)
+      | transform(from<dogs>, to<dogs>, 0.5, [](int dog) { return 2; }, prng)
+      | transform(from<dogs>, to<dogs>, 0.0, [](int dog) { return 3; }, prng);
+
+    std::vector<int> generated = unpack(rng, from<dogs>, dim<1>);
+    BOOST_CHECK(generated.size() == 6);
+    long number1 = ranges::count(generated, 1);
+    long number2 = ranges::count(generated, 2);
+    long number3 = ranges::count(generated, 3);
+    BOOST_TEST(number1 >= 1);
+    BOOST_TEST(number1 <= 5);
+    BOOST_TEST(number1 == 6 - number2);
+    BOOST_TEST(number3 == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only)
+{
+    auto data = generate_move_only_data();
+
+    auto rng = data
+      | ranges::view::move
+      | create<Int, UniqueVec>(2)
+      | drop<Int>
+      | transform(from<UniqueVec>, to<UniqueVec>, 0.5, [](std::unique_ptr<int>& ptr) {
+            return std::make_unique<int>(19);
+        }, prng, dim<2>)
+      | unique_vec_to_int_vec();
+
+    std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
+    long number = ranges::count(generated, 19);
+    BOOST_TEST(generated.size() == 6);
+    BOOST_TEST(number >= 1);
+    BOOST_TEST(number <= 5);
+}
+
+BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only_multicol)
+{
+    auto data = generate_move_only_data();
+
+    auto rng = data
+      | ranges::view::move
+      | create<Int, UniqueVec>(2)
+      | drop<Int>
+      // create IntVec column
+      | transform(from<UniqueVec>, to<IntVec>, [](auto&&) {
+            return 7;
+        }, dim<2>)
+      // probabilistically transform two columns to two columns
+      | transform(from<UniqueVec, IntVec>, to<IntVec, UniqueVec>, 0.5,
+          [](std::unique_ptr<int>& ptr, int val) {
+            return std::make_tuple(val, std::make_unique<int>(19));
+        }, prng, dim<2>)
+      // probabilistically transform two columns to one column
+      | transform(from<IntVec, UniqueVec>, to<UniqueVec>, 0.5,
+          [](int, std::unique_ptr<int>& ptr) {
+            return std::make_unique<int>(19);
+        }, prng, dim<2>)
+      | unique_vec_to_int_vec();  // the original IntVec gets overwritten here
+
+    std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
+    long number19 = ranges::count(generated, 19);
+    BOOST_TEST(generated.size() == 6);
+    BOOST_TEST(number19 >= 3);
 }

--- a/test/core/stream/transform.hpp
+++ b/test/core/stream/transform.hpp
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+#ifndef TEST_STREAM_TRANSFORM_HPP
+#define TEST_STREAM_TRANSFORM_HPP
+
+#include "../common.hpp"
+
+#include <cxtream/core/stream/create.hpp>
+#include <cxtream/core/stream/drop.hpp>
+#include <cxtream/core/stream/transform.hpp>
+#include <cxtream/core/stream/unpack.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/to_container.hpp>
+#include <range/v3/view/indirect.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/move.hpp>
+#include <range/v3/view/zip.hpp>
+
+#include <memory>
+#include <random>
+#include <tuple>
+#include <vector>
+
+// test with a seeded random generator
+std::mt19937 prng{1000003};
+
+auto unique_vec_to_int_vec()
+{
+    using namespace cxtream::stream;
+    return
+        transform(from<UniqueVec>, to<IntVec>, [](auto&& ptrs) {
+            return ptrs | ranges::view::indirect;
+        }, dim<1>)
+      | drop<UniqueVec>;
+}
+
+#endif

--- a/test/core/stream/transform1.cpp
+++ b/test/core/stream/transform1.cpp
@@ -7,44 +7,14 @@
  *  See the accompanying file LICENSE.txt for the complete license agreement.
  ****************************************************************************/
 
+// The tests for stream::transform are split to multiple
+// files to speed up compilation in case of multiple CPUs.
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE transform_test
+#define BOOST_TEST_MODULE transform1_test
 
-#include "../common.hpp"
-
-#include <cxtream/core/stream/create.hpp>
-#include <cxtream/core/stream/drop.hpp>
-#include <cxtream/core/stream/transform.hpp>
-#include <cxtream/core/stream/unpack.hpp>
-
-#include <boost/test/unit_test.hpp>
-#include <range/v3/algorithm/count.hpp>
-#include <range/v3/to_container.hpp>
-#include <range/v3/view/indirect.hpp>
-#include <range/v3/view/iota.hpp>
-#include <range/v3/view/move.hpp>
-#include <range/v3/view/zip.hpp>
-
-#include <memory>
-#include <tuple>
-#include <vector>
+#include "transform.hpp"
 
 using namespace cxtream::stream;
-
-// test with a seeded random generator
-std::mt19937 prng{1000003};
-
-CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
-CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
-
-auto unique_vec_to_int_vec()
-{
-    return
-        transform(from<UniqueVec>, to<IntVec>, [](auto&& ptrs) {
-            return ptrs | ranges::view::indirect;
-        }, dim<1>)
-      | drop<UniqueVec>;
-}
 
 BOOST_AUTO_TEST_CASE(test_partial_transform)
 {
@@ -204,75 +174,4 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only_mutable)
 #else
     BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
 #endif
-}
-
-BOOST_AUTO_TEST_CASE(test_probabilistic_simple)
-{
-    CXTREAM_DEFINE_COLUMN(dogs, int)
-    std::vector<int> data = {3, 1, 5, 7, 2, 13};
-    auto rng = data
-      | create<dogs>()
-      | transform(from<dogs>, to<dogs>, 1.0, [](int dog) { return 1; }, prng)
-      | transform(from<dogs>, to<dogs>, 0.5, [](int dog) { return 2; }, prng)
-      | transform(from<dogs>, to<dogs>, 0.0, [](int dog) { return 3; }, prng);
-
-    std::vector<int> generated = unpack(rng, from<dogs>, dim<1>);
-    BOOST_CHECK(generated.size() == 6);
-    long number1 = ranges::count(generated, 1);
-    long number2 = ranges::count(generated, 2);
-    long number3 = ranges::count(generated, 3);
-    BOOST_TEST(number1 >= 1);
-    BOOST_TEST(number1 <= 5);
-    BOOST_TEST(number1 == 6 - number2);
-    BOOST_TEST(number3 == 0);
-}
-
-BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only)
-{
-    auto data = generate_move_only_data();
-
-    auto rng = data
-      | ranges::view::move
-      | create<Int, UniqueVec>(2)
-      | drop<Int>
-      | transform(from<UniqueVec>, to<UniqueVec>, 0.5, [](std::unique_ptr<int>& ptr) {
-            return std::make_unique<int>(19);
-        }, prng, dim<2>)
-      | unique_vec_to_int_vec();
-
-    std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
-    long number = ranges::count(generated, 19);
-    BOOST_TEST(generated.size() == 6);
-    BOOST_TEST(number >= 1);
-    BOOST_TEST(number <= 5);
-}
-
-BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only_multicol)
-{
-    auto data = generate_move_only_data();
-
-    auto rng = data
-      | ranges::view::move
-      | create<Int, UniqueVec>(2)
-      | drop<Int>
-      // create IntVec column
-      | transform(from<UniqueVec>, to<IntVec>, [](auto&&) {
-            return 7;
-        }, dim<2>)
-      // probabilistically transform two columns to two columns
-      | transform(from<UniqueVec, IntVec>, to<IntVec, UniqueVec>, 0.5,
-          [](std::unique_ptr<int>& ptr, int val) {
-            return std::make_tuple(val, std::make_unique<int>(19));
-        }, prng, dim<2>)
-      // probabilistically transform two columns to one column
-      | transform(from<IntVec, UniqueVec>, to<UniqueVec>, 0.5,
-          [](int, std::unique_ptr<int>& ptr) {
-            return std::make_unique<int>(19);
-        }, prng, dim<2>)
-      | unique_vec_to_int_vec();  // the original IntVec gets overwritten here
-
-    std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
-    long number19 = ranges::count(generated, 19);
-    BOOST_TEST(generated.size() == 6);
-    BOOST_TEST(number19 >= 3);
 }

--- a/test/core/stream/transform2.cpp
+++ b/test/core/stream/transform2.cpp
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+// The tests for stream::transform are split to multiple
+// files to speed up compilation in case of multiple CPUs.
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE transform2_test
+
+#include "transform.hpp"
+
+using namespace cxtream::stream;
+
+BOOST_AUTO_TEST_CASE(test_probabilistic_simple)
+{
+    CXTREAM_DEFINE_COLUMN(dogs, int)
+    std::vector<int> data = {3, 1, 5, 7, 2, 13};
+    auto rng = data
+      | create<dogs>()
+      | transform(from<dogs>, to<dogs>, 1.0, [](int dog) { return 1; }, prng)
+      | transform(from<dogs>, to<dogs>, 0.5, [](int dog) { return 2; }, prng)
+      | transform(from<dogs>, to<dogs>, 0.0, [](int dog) { return 3; }, prng);
+
+    std::vector<int> generated = unpack(rng, from<dogs>, dim<1>);
+    BOOST_CHECK(generated.size() == 6);
+    long number1 = ranges::count(generated, 1);
+    long number2 = ranges::count(generated, 2);
+    long number3 = ranges::count(generated, 3);
+    BOOST_TEST(number1 >= 1);
+    BOOST_TEST(number1 <= 5);
+    BOOST_TEST(number1 == 6 - number2);
+    BOOST_TEST(number3 == 0);
+}

--- a/test/core/stream/transform3.cpp
+++ b/test/core/stream/transform3.cpp
@@ -28,10 +28,10 @@ BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only)
       | transform(from<UniqueVec>, to<IntVec>, [](auto&&) {
             return 7;
         }, dim<2>)
-      // probabilistically transform a single columns to itself
-      | transform(from<UniqueVec>, to<UniqueVec>, 0.0,
-          [](std::unique_ptr<int>& ptr) {
-            return std::make_unique<int>(20);
+      // probabilistically transform a single columns to a different column
+      | transform(from<IntVec>, to<UniqueVec>, 1.0,
+          [](int) {
+            return std::make_unique<int>(18);
         }, prng, dim<2>)
       // probabilistically transform two columns to two columns
       | transform(from<UniqueVec, IntVec>, to<IntVec, UniqueVec>, 0.5,
@@ -46,9 +46,9 @@ BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only)
       | unique_vec_to_int_vec();  // the original IntVec gets overwritten here
 
     std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
+    long number18 = ranges::count(generated, 18);
     long number19 = ranges::count(generated, 19);
-    long number20 = ranges::count(generated, 20);
     BOOST_TEST(generated.size() == 6);
     BOOST_TEST(number19 >= 3);
-    BOOST_TEST(number20 == 0);
+    BOOST_TEST(number19 == 6 - number18);
 }

--- a/test/core/stream/transform3.cpp
+++ b/test/core/stream/transform3.cpp
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+// The tests for stream::transform are split to multiple
+// files to speed up compilation in case of multiple CPUs.
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE transform3_test
+
+#include "transform.hpp"
+
+using namespace cxtream::stream;
+
+BOOST_AUTO_TEST_CASE(test_probabilistic_dim2_move_only)
+{
+    auto data = generate_move_only_data();
+
+    auto rng = data
+      | ranges::view::move
+      | create<Int, UniqueVec>(2)
+      | drop<Int>
+      // create IntVec column
+      | transform(from<UniqueVec>, to<IntVec>, [](auto&&) {
+            return 7;
+        }, dim<2>)
+      // probabilistically transform a single columns to itself
+      | transform(from<UniqueVec>, to<UniqueVec>, 0.0,
+          [](std::unique_ptr<int>& ptr) {
+            return std::make_unique<int>(20);
+        }, prng, dim<2>)
+      // probabilistically transform two columns to two columns
+      | transform(from<UniqueVec, IntVec>, to<IntVec, UniqueVec>, 0.5,
+          [](std::unique_ptr<int>& ptr, int val) {
+            return std::make_tuple(val, std::make_unique<int>(19));
+        }, prng, dim<2>)
+      // probabilistically transform two columns to one column
+      | transform(from<IntVec, UniqueVec>, to<UniqueVec>, 0.5,
+          [](int, std::unique_ptr<int>& ptr) {
+            return std::make_unique<int>(19);
+        }, prng, dim<2>)
+      | unique_vec_to_int_vec();  // the original IntVec gets overwritten here
+
+    std::vector<int> generated = unpack(rng, from<IntVec>, dim<2>);
+    long number19 = ranges::count(generated, 19);
+    long number20 = ranges::count(generated, 20);
+    BOOST_TEST(generated.size() == 6);
+    BOOST_TEST(number19 >= 3);
+    BOOST_TEST(number20 == 0);
+}

--- a/test/core/stream/unpack.cpp
+++ b/test/core/stream/unpack.cpp
@@ -26,9 +26,6 @@
 
 using namespace cxtream::stream;
 
-CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
-CXTREAM_DEFINE_COLUMN(UniqueVec, std::vector<std::unique_ptr<int>>)
-
 std::vector<std::tuple<int, std::vector<int>>> generate_data()
 {
     return {{3, {1, 4}}, {1, {8, 2}}, {7, {2, 5}}};

--- a/test/core/utility/tuple.cpp
+++ b/test/core/utility/tuple.cpp
@@ -36,6 +36,24 @@ BOOST_AUTO_TEST_CASE(test_variadic_find)
     static_assert(variadic_find<float, int, double, float>::value == 2);
 }
 
+BOOST_AUTO_TEST_CASE(test_plus_index_sequence)
+{
+    static_assert(std::is_same<decltype(plus<2>(std::index_sequence<1, 3, 4>{})),
+                                                std::index_sequence<3, 5, 6>>{});
+    static_assert(std::is_same<decltype(plus<0>(std::index_sequence<1, 3, 4>{})),
+                                                std::index_sequence<1, 3, 4>>{});
+    static_assert(std::is_same<decltype(plus<1>(std::index_sequence<>{})),
+                                                std::index_sequence<>>{});
+}
+
+BOOST_AUTO_TEST_CASE(test_make_offset_index_sequence)
+{
+    static_assert(std::is_same<decltype(make_offset_index_sequence<3, 4>()),
+                               std::index_sequence<3, 4, 5, 6>>{});
+    static_assert(std::is_same<decltype(make_offset_index_sequence<3, 0>()),
+                               std::index_sequence<>>{});
+}
+
 BOOST_AUTO_TEST_CASE(test_tuple_contains)
 {
     // tuple_contains


### PR DESCRIPTION
Example:
```c++
CXTREAM_DEFINE_COLUMN(dogs, int)
std::vector<int> data = {3, 1, 5, 7};
auto rng = data
  | create<dogs>()
  // In 50% of the cases, the number of dogs increase,
  // and in the other 50% of the cases, it stays the same.
  | transform(from<dogs>, to<dogs>, 0.5, [](int dog) { return dog + 1; });
```
