### PR TITLE
N-dimensional ranges

### DIFF
--- a/include/cxtream/core/stream/random_fill.hpp
+++ b/include/cxtream/core/stream/random_fill.hpp
@@ -11,6 +11,7 @@
 #define CXTREAM_CORE_STREAM_RANDOM_FILL_HPP
 
 #include <cxtream/core/stream/transform.hpp>
+#include <cxtream/core/utility/random.hpp>
 #include <cxtream/core/utility/vector.hpp>
 
 #include <range/v3/view/take.hpp>
@@ -48,7 +49,7 @@ template<typename FromColumn, typename ToColumn, typename Prng = std::mt19937>
 constexpr auto random_fill(from_t<FromColumn> size_from,
                            to_t<ToColumn> fill_to,
                            long ndims = std::numeric_limits<long>::max(),
-                           Prng&& gen = Prng{std::random_device{}()})
+                           Prng& gen = cxtream::utility::random_generator)
 {
     auto fun = [ndims, &gen](const auto& source) -> ToColumn {
         using SourceVector = std::decay_t<decltype(source)>;

--- a/include/cxtream/core/stream/random_fill.hpp
+++ b/include/cxtream/core/stream/random_fill.hpp
@@ -23,35 +23,39 @@ namespace cxtream::stream {
 /// Fill the selected column of a stream with random values.
 ///
 /// This function uses utility::vector::random_fill(). Furthermore, the column to be filled
-/// is first resized so that it has the same shape as the selected source column.
+/// is first resized so that it has the same size as the selected source column.
 ///
-/// The selected `from` column has to be a multidimensional std::vector with dimension
-/// at least as large as the column to be filled. This can be worked around by manually
-/// preparing the size of the column to be filled and than using it as both `from` column
-/// and `to` column.
+/// The selected `from` column has to be a multidimensional range with the number of
+/// dimensions at least as large as the `to` column (i.e., the column to be filled).
+///
+/// If there is no column from which should the size be taken, than just resize
+/// the target column manually and use it as both `from` column and `to` column.
 ///
 /// Example:
 /// \code
 ///     CXTREAM_DEFINE_COLUMN(id, int)
-///     CXTREAM_DEFINE_COLUMN(category, std::uint64_t)
+///     CXTREAM_DEFINE_COLUMN(value, double)
 ///     std::vector<int> data = {3, 1, 2};
 ///     auto rng = data
 ///       | create<id>()
-///       | random_fill(from<id>, to<category>);
-///       | transform(from<id, category>, [](...){ ... });
+///       | random_fill(from<id>, to<value>);
+///       | transform(from<id, value>, [](...){ ... });
 /// \endcode
 ///
 /// \param size_from The column whose size will be used to initialize the random column.
 /// \param fill_to The column to be filled with random data.
 /// \param ndims The number of random dimensions. See utility::vector::random_fill().
 /// \param gen The random generator to be used.
-template<typename FromColumn, typename ToColumn, typename Prng = std::mt19937>
+/// \param dist The random distribution to be used.
+template<typename FromColumn, typename ToColumn, typename Prng = std::mt19937,
+         typename Dist = std::uniform_real_distribution<double>>
 constexpr auto random_fill(from_t<FromColumn> size_from,
                            to_t<ToColumn> fill_to,
                            long ndims = std::numeric_limits<long>::max(),
-                           Prng& gen = cxtream::utility::random_generator)
+                           Prng& gen = cxtream::utility::random_generator,
+                           Dist dist = Dist{0, 1})
 {
-    auto fun = [ndims, &gen](const auto& source) -> ToColumn {
+    auto fun = [ndims, &gen, dist](const auto& source) -> ToColumn {
         using SourceVector = std::decay_t<decltype(source)>;
         using TargetVector = std::decay_t<decltype(std::declval<ToColumn>().value())>;
         static_assert(utility::ndims<TargetVector>{} <= utility::ndims<SourceVector>{});
@@ -60,7 +64,7 @@ constexpr auto random_fill(from_t<FromColumn> size_from,
         TargetVector target;
         if (!std::is_same<FromColumn, ToColumn>{})
             utility::ndim_resize(target, target_size);
-        utility::random_fill(target, ndims, gen);
+        utility::random_fill(target, ndims, gen, Dist{dist});
         return target;
     };
     return transform(from<FromColumn>, to<ToColumn>, std::move(fun), dim<0>);

--- a/include/cxtream/core/stream/random_fill.hpp
+++ b/include/cxtream/core/stream/random_fill.hpp
@@ -14,15 +14,13 @@
 #include <cxtream/core/utility/random.hpp>
 #include <cxtream/core/utility/vector.hpp>
 
-#include <range/v3/view/take.hpp>
-
 #include <random>
 
 namespace cxtream::stream {
 
 /// Fill the selected column of a stream with random values.
 ///
-/// This function uses utility::vector::random_fill(). Furthermore, the column to be filled
+/// This function uses utility::random_fill(). Furthermore, the column to be filled
 /// is first resized so that it has the same size as the selected source column.
 ///
 /// The selected `from` column has to be a multidimensional range with the number of
@@ -44,30 +42,31 @@ namespace cxtream::stream {
 ///
 /// \param size_from The column whose size will be used to initialize the random column.
 /// \param fill_to The column to be filled with random data.
-/// \param ndims The number of random dimensions. See utility::vector::random_fill().
+/// \param rnddims The number of random dimensions. See utility::random_fill().
 /// \param gen The random generator to be used.
 /// \param dist The random distribution to be used.
 template<typename FromColumn, typename ToColumn, typename Prng = std::mt19937,
          typename Dist = std::uniform_real_distribution<double>>
 constexpr auto random_fill(from_t<FromColumn> size_from,
                            to_t<ToColumn> fill_to,
-                           long ndims = std::numeric_limits<long>::max(),
+                           long rnddims = std::numeric_limits<long>::max(),
                            Prng& gen = cxtream::utility::random_generator,
                            Dist dist = Dist{0, 1})
 {
-    auto fun = [ndims, &gen, dist](const auto& source) -> ToColumn {
+    auto fun = [rnddims, &gen, dist](const auto& source) -> ToColumn {
         using SourceVector = std::decay_t<decltype(source)>;
         using TargetVector = std::decay_t<decltype(std::declval<ToColumn>().value())>;
-        static_assert(utility::ndims<TargetVector>{} <= utility::ndims<SourceVector>{});
-        std::vector<std::vector<long>> target_size = utility::ndim_size(source);
-        target_size = target_size | ranges::view::take(utility::ndims<TargetVector>{}());
+        constexpr long TargetDims = utility::ndims<TargetVector>::value;
+        static_assert(TargetDims <= utility::ndims<SourceVector>::value);
+        // get the size of the source up to the dimension of the target
+        std::vector<std::vector<long>> target_size = utility::ndim_size<TargetDims>(source);
+        // create, resize, and fill the target with random values
         TargetVector target;
-        if (!std::is_same<FromColumn, ToColumn>{})
-            utility::ndim_resize(target, target_size);
-        utility::random_fill(target, ndims, gen, Dist{dist});
+        utility::ndim_resize(target, target_size);
+        utility::random_fill(target, rnddims, gen, Dist{dist});
         return target;
     };
-    return transform(from<FromColumn>, to<ToColumn>, std::move(fun), dim<0>);
+    return ::cxtream::stream::transform(from<FromColumn>, to<ToColumn>, std::move(fun), dim<0>);
 }
 
 }  // namespace cxtream::stream

--- a/include/cxtream/core/stream/transform.hpp
+++ b/include/cxtream/core/stream/transform.hpp
@@ -162,7 +162,7 @@ namespace detail {
           std::index_sequence<FromIndices...> from_indices,
           std::index_sequence<ToIndices...> to_indices)
         {
-            return [fun = std::move(fun), &prng, prob, from_indices, to_indices]
+            return [fun = std::move(fun), &prng, prob, to_indices]
               (auto&... cols) CXTREAM_MUTABLE_LAMBDA_V {
                 std::uniform_real_distribution<> dis(0, 1);
                 // make a tuple of all arguments

--- a/include/cxtream/core/utility/vector.hpp
+++ b/include/cxtream/core/utility/vector.hpp
@@ -348,7 +348,7 @@ auto flat_view(Rng&& rng)
     return ::cxtream::utility::flat_view<ndims<Rng>{}>(std::forward<Rng>(rng));
 }
 
-// std::vector reshape //
+// reshaped view of a multidimensional range //
 
 namespace detail {
 
@@ -371,8 +371,8 @@ namespace detail {
         }
     };
 
-    template<long N, typename Vector>
-    auto reshaped_view_impl(Vector& vec, std::vector<long> shape)
+    template<long N, typename Rng>
+    auto reshaped_view_impl(Rng& vec, std::vector<long> shape)
     {
         assert(shape.size() == N);
         auto flat = flat_view(vec);
@@ -400,32 +400,32 @@ namespace detail {
 
 }  // namespace detail
 
-/// Makes a view of a multidimensional std::vector with a specific shape.
+/// Makes a view of a multidimensional range with a specific shape.
 ///
 /// Usage:
 /// \code
-///     std::vector<int> vec{1, 2, 3, 4, 5, 6};
-///     std::vector<std::vector<int>> rvec = reshaped_view<2>(vec, {2, 3});
-///     // rvec == {{1, 2, 3}, {4, 5, 6}};
+///     std::list<int> lst{1, 2, 3, 4, 5, 6};
+///     std::vector<std::vector<int>> rlst = reshaped_view<2>(lst, {2, 3});
+///     // rlst == {{1, 2, 3}, {4, 5, 6}};
 /// \endcode
 ///
-/// \param vec The base vector for the view.
+/// \param rng The base range for the view.
 /// \param shape The list of shapes. Those can contain a single -1, which denotes
 ///              that the dimension size shall be automatically deduced. All the other values
 ///              have to be positive.
 /// \tparam N The number of dimensions. Has to be equal to shape.size().
-/// \returns View (InputRange) of the original vector with the given shape.
-template<long N, typename T>
-auto reshaped_view(std::vector<T>& vec, std::vector<long> shape)
+/// \returns View (InputRange) of the original range with the given shape.
+template<long N, typename Rng>
+auto reshaped_view(Rng& rng, std::vector<long> shape)
 {
-    return detail::reshaped_view_impl<N, std::vector<T>>(vec, std::move(shape));
+    return detail::reshaped_view_impl<N, Rng>(rng, std::move(shape));
 }
 
 /// Const version of reshaped_view.
-template<long N, typename T>
-auto reshaped_view(const std::vector<T>& vec, std::vector<long> shape)
+template<long N, typename Rng>
+auto reshaped_view(const Rng& rng, std::vector<long> shape)
 {
-    return detail::reshaped_view_impl<N, const std::vector<T>>(vec, std::move(shape));
+    return detail::reshaped_view_impl<N, const Rng>(rng, std::move(shape));
 }
 
 // random fill //

--- a/include/cxtream/core/utility/vector.hpp
+++ b/include/cxtream/core/utility/vector.hpp
@@ -489,6 +489,7 @@ namespace detail {
 /// \param vec The vector to be filled.
 /// \param ndims The random generator will be used only for this number of dimension. The
 ///              rest of the dimensions will be filled by the last generated value.
+///              Use std::numeric_limits<long>::max() to randomly fill all dimensions.
 /// \param gen The random generator to be used.
 /// \param dist The distribution to be used.
 template<typename T, typename Prng = std::mt19937&,

--- a/include/cxtream/python/utility/pyboost_ndarray_converter.hpp
+++ b/include/cxtream/python/utility/pyboost_ndarray_converter.hpp
@@ -50,7 +50,7 @@ namespace detail {
                                                                        \
         static NP_TYPE convert(C_TYPE val)                             \
         {                                                              \
-            return {val};                                              \
+            return val;                                                \
         }                                                              \
                                                                        \
         static int typenum()                                           \

--- a/test/core/stream/random_fill.cpp
+++ b/test/core/stream/random_fill.cpp
@@ -27,7 +27,7 @@ using namespace cxtream::stream;
 using namespace cxtream::utility;
 
 CXTREAM_DEFINE_COLUMN(IntVec2d, std::vector<std::vector<int>>)
-CXTREAM_DEFINE_COLUMN(Random, std::vector<std::uint64_t>)
+CXTREAM_DEFINE_COLUMN(Random, std::vector<double>)
 
 template<typename Vector2d>
 void check(Vector2d vec, std::vector<long> unique, long unique_total)
@@ -38,7 +38,7 @@ void check(Vector2d vec, std::vector<long> unique, long unique_total)
         BOOST_TEST(n_unique == unique.at(i));
     }
 
-    std::vector<std::uint64_t> all_vals = flat_view(vec);
+    std::vector<double> all_vals = flat_view(vec);
     all_vals |= ranges::action::sort;
     auto n_unique = ranges::distance(all_vals | ranges::view::unique);
     BOOST_TEST(n_unique == unique_total);
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_simple)
       | random_fill(from<IntVec2d>, to<Random>, 1, gen);
 
     int batch_i = 0;
-    std::vector<std::vector<std::uint64_t>> all_random;
+    std::vector<std::vector<double>> all_random;
     for (auto batch : stream) {
         auto random = std::get<Random>(batch).value();
         switch (batch_i) {

--- a/test/core/utility/vector.cpp
+++ b/test/core/utility/vector.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(test_ndim_resize)
 
 BOOST_AUTO_TEST_CASE(test_flatten)
 {
-    const std::vector<std::vector<std::vector<int>>> vec = {
+    const std::vector<std::list<std::vector<int>>> vec = {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
       {{10, 11, 12}, {13, 14, 15}}
     };
@@ -154,30 +154,30 @@ BOOST_AUTO_TEST_CASE(test_flatten_identity)
 
 BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim1)
 {
-    const std::vector<std::vector<std::vector<int>>> vec = {
+    const std::list<std::vector<std::vector<int>>> vec = {
       {{1, 2}, {3, 4}, {5}},
       {{6}, {7, 8}}
     };
     std::vector<std::vector<std::vector<int>>> retrieved = flat_view<1>(vec);
-    BOOST_CHECK(retrieved == vec);
+    test_ranges_equal(retrieved, vec);
 }
 
 BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim2)
 {
-    const std::vector<std::vector<std::vector<int>>> vec = {
+    const std::vector<std::vector<std::list<int>>> vec = {
       {{1, 2}, {3, 4}, {5}},
       {{6}, {7, 8}}
     };
-    const std::vector<std::vector<int>> desired = {
+    const std::vector<std::list<int>> desired = {
       {{1, 2}, {3, 4}, {5}, {6}, {7, 8}}
     };
-    std::vector<std::vector<int>> retrieved = flat_view<2>(vec);
+    std::vector<std::list<int>> retrieved = flat_view<2>(vec);
     BOOST_CHECK(retrieved == desired);
 }
 
 BOOST_AUTO_TEST_CASE(test_flatten_empty)
 {
-    std::vector<std::vector<std::vector<int>>> vec = {
+    std::list<std::vector<std::vector<int>>> vec = {
       {{}, {}, {}},
       {}
     };
@@ -188,12 +188,12 @@ BOOST_AUTO_TEST_CASE(test_flatten_empty)
 
 BOOST_AUTO_TEST_CASE(test_flatten_move_only)
 {
-    std::vector<std::vector<std::unique_ptr<int>>> vec;
-    std::vector<std::unique_ptr<int>> inner;
+    std::vector<std::list<std::unique_ptr<int>>> vec;
+    std::list<std::unique_ptr<int>> inner;
     inner.push_back(std::make_unique<int>(1));
     inner.push_back(std::make_unique<int>(2));
     vec.push_back(std::move(inner));
-    inner = std::vector<std::unique_ptr<int>>{};
+    inner = std::list<std::unique_ptr<int>>{};
     inner.push_back(std::make_unique<int>(3));
     inner.push_back(std::make_unique<int>(4));
     vec.push_back(std::move(inner));

--- a/test/core/utility/vector.cpp
+++ b/test/core/utility/vector.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(test_flatten_move_only)
 
 BOOST_AUTO_TEST_CASE(test_reshape_1d)
 {
-    std::vector<std::vector<std::vector<int>>> vec = {
+    std::vector<std::list<std::vector<int>>> vec = {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
       {{10, 11, 12}, {13, 14, 15}}
     };
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(test_reshape_1d)
 
 BOOST_AUTO_TEST_CASE(test_reshape_2d)
 {
-    const std::vector<std::vector<std::vector<int>>> vec = {
+    const std::list<std::vector<std::vector<int>>> vec = {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
       {{10, 11, 12}, {13, 14, 15}}
     };
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(test_reshape_2d)
 
 BOOST_AUTO_TEST_CASE(test_reshape_3d)
 {
-    std::vector<std::vector<std::vector<int>>> vec = {
+    std::vector<std::vector<std::list<int>>> vec = {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
       {{10, 11, 12}, {13, 14, 15}}
     };
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(test_reshape_3d)
 
 BOOST_AUTO_TEST_CASE(test_reshape_auto_dimension)
 {
-    const std::vector<std::vector<std::vector<int>>> vec = {
+    const std::list<std::vector<std::vector<int>>> vec = {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
       {{10, 11, 12}, {13, 14, 15}}
     };
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(test_reshape_auto_dimension)
 
 BOOST_AUTO_TEST_CASE(test_reshape_move_only)
 {
-    std::vector<std::vector<std::unique_ptr<int>>> vec;
+    std::list<std::vector<std::unique_ptr<int>>> vec;
     std::vector<std::unique_ptr<int>> inner;
     inner.push_back(std::make_unique<int>(1));
     inner.push_back(std::make_unique<int>(2));

--- a/test/core/utility/vector.cpp
+++ b/test/core/utility/vector.cpp
@@ -54,77 +54,60 @@ BOOST_AUTO_TEST_CASE(test_ndim_type_cutoff)
       ndim_type<std::list<std::vector<std::vector<double>>>, 2>::type>{});
 }
 
-BOOST_AUTO_TEST_CASE(test_ndim_size)
-{
-    const std::vector<int> vec =
-      {};
-    const std::vector<int> vec5 =
-      {0, 0, 0, 0, 0};
-    std::vector<std::vector<int>> vec3231 =
-      {{0, 0}, {0, 0, 0}, {0}};
-    const std::list<std::vector<std::vector<int>>> vec3302 =
-      {
-        {{0, 0, 0, 0}, {0, 0, 0}, {0, 0}},
-        {},
-        {{0}, {}}
-      };
-    std::vector<std::list<std::vector<int>>> vec200 =
-      {{}, {}};
-
-    test_ranges_equal(ndim_size(vec),
-      std::vector<std::vector<long>>{{0}});
-    test_ranges_equal(ndim_size(vec5),
-      std::vector<std::vector<long>>{{5}});
-    test_ranges_equal(ndim_size(vec3231),
-      std::vector<std::vector<long>>{{3}, {2, 3, 1}});
-    test_ranges_equal(ndim_size(vec3302),
-      std::vector<std::vector<long>>{{3}, {3, 0, 2}, {4, 3, 2, 1, 0}});
-    test_ranges_equal(ndim_size(vec200),
-      std::vector<std::vector<long>>{{2}, {0, 0}, {}});
-}
-
 BOOST_AUTO_TEST_CASE(test_ndim_size_cutoff)
 {
-    const std::vector<int> vec =
-      {};
-    const std::vector<int> vec5 =
-      {0, 0, 0, 0, 0};
-    std::vector<std::vector<int>> vec3231 =
-      {{0, 0}, {0, 0, 0}, {0}};
-    const std::list<std::vector<std::vector<int>>> vec3302 =
-      {
-        {{0, 0, 0, 0}, {0, 0, 0}, {0, 0}},
-        {},
-        {{0}, {}}
-      };
-    std::vector<std::list<std::vector<int>>> vec200 =
-      {{}, {}};
+    const std::vector<int> vec = {};
+    const std::vector<int> vec5 = {0, 0, 0, 0, 0};
+    std::vector<std::vector<int>> vec3231 = {{0, 0}, {0, 0, 0}, {0}};
+    const std::list<std::vector<std::vector<int>>> vec3302 = {
+      {{0, 0, 0, 0}, {0, 0, 0}, {0, 0}},
+      {},
+      {{0}, {}}
+    };
+    std::vector<std::list<std::vector<int>>> vec200 = {{}, {}};
 
     test_ranges_equal(ndim_size<1>(vec),
       std::vector<std::vector<long>>{{0}});
-    test_ranges_equal(ndim_size<0>(vec5),
-      std::vector<std::vector<long>>{});
+    test_ranges_equal(ndim_size<1>(vec5),
+      std::vector<std::vector<long>>{{5}});
     test_ranges_equal(ndim_size<1>(vec3231),
       std::vector<std::vector<long>>{{3}});
     test_ranges_equal(ndim_size<2>(vec3302),
       std::vector<std::vector<long>>{{3}, {3, 0, 2}});
-    test_ranges_equal(ndim_size<5>(vec200),
+    test_ranges_equal(ndim_size<3>(vec200),
       std::vector<std::vector<long>>{{2}, {0, 0}, {}});
+}
+
+BOOST_AUTO_TEST_CASE(test_ndim_size_default)
+{
+    // if the ndims<> function works correctly, this test is only necessary
+    // to check whether the code compiles fine
+    std::vector<std::vector<int>> vec3231 = {{0, 0}, {0, 0, 0}, {0}};
+    test_ranges_equal(ndim_size(vec3231), std::vector<std::vector<long>>{{3}, {2, 3, 1}});
+}
+
+BOOST_AUTO_TEST_CASE(test_shape_cutoff)
+{
+    const std::vector<int> vec5 = {0, 0, 0, 0, 0};
+    std::vector<std::list<int>> vec23 = {{0, 0, 0}, {0, 0, 0}};
+    const std::list<std::vector<std::vector<int>>> vec234 = {
+      {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+      {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+    };
+    std::vector<std::vector<std::vector<int>>> vec200 = {{}, {}};
+
+    test_ranges_equal(shape<1>(vec5),  std::vector<long>{5});
+    test_ranges_equal(shape<1>(vec23), std::vector<long>{2});
+    test_ranges_equal(shape<2>(vec234), std::vector<long>{2, 3});
+    test_ranges_equal(shape<3>(vec200), std::vector<long>{2, 0, 0});
 }
 
 BOOST_AUTO_TEST_CASE(test_shape)
 {
-    const std::vector<int> vec5 = {0, 0, 0, 0, 0};
-    std::vector<std::vector<int>> vec23 = {{0, 0, 0}, {0, 0, 0}};
-    const std::vector<std::vector<std::vector<int>>> vec234 = {
-        {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
-        {{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
-    };
-    std::vector<std::vector<std::vector<int>>> vec200 = {{}, {}};
-    test_ranges_equal(shape(vec5),  std::vector<long>{5});
+    // if the ndims<> function works correctly, this test is only necessary
+    // to check whether the code compiles fine
+    std::vector<std::list<int>> vec23 = {{0, 0, 0}, {0, 0, 0}};
     test_ranges_equal(shape(vec23), std::vector<long>{2, 3});
-    test_ranges_equal(shape(vec234), std::vector<long>{2, 3, 4});
-    test_ranges_equal(shape(vec200), std::vector<long>{2, 0, 0});
 }
 
 BOOST_AUTO_TEST_CASE(test_ndim_resize)
@@ -137,9 +120,9 @@ BOOST_AUTO_TEST_CASE(test_ndim_resize)
     std::vector<int> vec5_desired = {7, 8, 9, 1, 1};
     std::vector<std::vector<int>> vec3231_desired = {{1, 1}, {3, 4, 2}, {2}};
     std::vector<std::vector<std::vector<int>>> vec3302_desired = {
-        {{0, 0, 0, 0}, {0, 0, 0}, {0, 0}},
-        {},
-        {{0}, {}}
+      {{0, 0, 0, 0}, {0, 0, 0}, {0, 0}},
+      {},
+      {{0}, {}}
     };
     std::vector<std::vector<std::vector<int>>> vec200_desired = {{}, {}};
 
@@ -157,8 +140,8 @@ BOOST_AUTO_TEST_CASE(test_ndim_resize)
 BOOST_AUTO_TEST_CASE(test_flatten)
 {
     const std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
-        {{10, 11, 12}, {13, 14, 15}}
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+      {{10, 11, 12}, {13, 14, 15}}
     };
     test_ranges_equal(flat_view(vec), ranges::view::iota(1, 16));
 }
@@ -172,8 +155,8 @@ BOOST_AUTO_TEST_CASE(test_flatten_identity)
 BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim1)
 {
     const std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2}, {3, 4}, {5}},
-        {{6}, {7, 8}}
+      {{1, 2}, {3, 4}, {5}},
+      {{6}, {7, 8}}
     };
     std::vector<std::vector<std::vector<int>>> retrieved = flat_view<1>(vec);
     BOOST_CHECK(retrieved == vec);
@@ -182,11 +165,11 @@ BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim1)
 BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim2)
 {
     const std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2}, {3, 4}, {5}},
-        {{6}, {7, 8}}
+      {{1, 2}, {3, 4}, {5}},
+      {{6}, {7, 8}}
     };
     const std::vector<std::vector<int>> desired = {
-        {{1, 2}, {3, 4}, {5}, {6}, {7, 8}}
+      {{1, 2}, {3, 4}, {5}, {6}, {7, 8}}
     };
     std::vector<std::vector<int>> retrieved = flat_view<2>(vec);
     BOOST_CHECK(retrieved == desired);
@@ -195,8 +178,8 @@ BOOST_AUTO_TEST_CASE(test_flatten_cutoff_dim2)
 BOOST_AUTO_TEST_CASE(test_flatten_empty)
 {
     std::vector<std::vector<std::vector<int>>> vec = {
-        {{}, {}, {}},
-        {}
+      {{}, {}, {}},
+      {}
     };
     test_ranges_equal(flat_view(vec), std::vector<int>{});
     std::vector<int> vec2 = {};
@@ -221,8 +204,8 @@ BOOST_AUTO_TEST_CASE(test_flatten_move_only)
 BOOST_AUTO_TEST_CASE(test_reshape_1d)
 {
     std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
-        {{10, 11, 12}, {13, 14, 15}}
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+      {{10, 11, 12}, {13, 14, 15}}
     };
     std::vector<int> rvec = reshaped_view<1>(vec, {15});
     BOOST_TEST(rvec.size() == 15);
@@ -232,8 +215,8 @@ BOOST_AUTO_TEST_CASE(test_reshape_1d)
 BOOST_AUTO_TEST_CASE(test_reshape_2d)
 {
     const std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
-        {{10, 11, 12}, {13, 14, 15}}
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+      {{10, 11, 12}, {13, 14, 15}}
     };
     std::vector<std::vector<int>> rvec = reshaped_view<2>(vec, {3, 5});
     BOOST_TEST(rvec.size() == 3);
@@ -246,8 +229,8 @@ BOOST_AUTO_TEST_CASE(test_reshape_2d)
 BOOST_AUTO_TEST_CASE(test_reshape_3d)
 {
     std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
-        {{10, 11, 12}, {13, 14, 15}}
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+      {{10, 11, 12}, {13, 14, 15}}
     };
     std::vector<std::vector<std::vector<int>>> rvec = reshaped_view<3>(vec, {3, 1, 5});
     BOOST_TEST(rvec.size() == 3);
@@ -260,8 +243,8 @@ BOOST_AUTO_TEST_CASE(test_reshape_3d)
 BOOST_AUTO_TEST_CASE(test_reshape_auto_dimension)
 {
     const std::vector<std::vector<std::vector<int>>> vec = {
-        {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
-        {{10, 11, 12}, {13, 14, 15}}
+      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}},
+      {{10, 11, 12}, {13, 14, 15}}
     };
     std::vector<std::vector<int>> rvec1 = reshaped_view<2>(vec, {3, -1});
     std::vector<std::vector<int>> rvec2 = reshaped_view<2>(vec, {-1, 5});

--- a/test/core/utility/vector.cpp
+++ b/test/core/utility/vector.cpp
@@ -277,15 +277,16 @@ BOOST_AUTO_TEST_CASE(test_reshape_move_only)
 BOOST_AUTO_TEST_CASE(test_random_fill_1d)
 {
     std::mt19937 gen{1000003};
-    std::vector<std::uint64_t> vec(10);
+    std::uniform_int_distribution<long> dist{0, 1000000000};
+    std::vector<long> vec(10);
 
-    random_fill(vec, 0, gen);
+    random_fill(vec, 0, gen, dist);
     BOOST_TEST(vec.size() == 10);
     vec |= ranges::action::sort;
     auto n_unique = ranges::distance(vec | ranges::view::unique);
     BOOST_TEST(n_unique == 1);
 
-    random_fill(vec, 5, gen);  // any number larger than 0 should suffice
+    random_fill(vec, 5, gen, dist);  // any number larger than 0 should suffice
     BOOST_TEST(vec.size() == 10);
     vec |= ranges::action::sort;
     n_unique = ranges::distance(vec | ranges::view::unique);
@@ -295,8 +296,8 @@ BOOST_AUTO_TEST_CASE(test_random_fill_1d)
 BOOST_AUTO_TEST_CASE(test_random_fill_2d)
 {
     std::mt19937 gen{1000003};
-    std::vector<std::vector<std::uint64_t>> vec = {std::vector<std::uint64_t>(10),
-                                                   std::vector<std::uint64_t>(5)};
+    std::vector<std::vector<double>> vec = {std::vector<double>(10),
+                                            std::vector<double>(5)};
 
     auto check = [](auto vec, std::vector<long> unique, long unique_total) {
         for (std::size_t i = 0; i < vec.size(); ++i) {
@@ -305,7 +306,7 @@ BOOST_AUTO_TEST_CASE(test_random_fill_2d)
             BOOST_TEST(n_unique == unique[i]);
         }
 
-        std::vector<std::uint64_t> all_vals = flat_view(vec);
+        std::vector<double> all_vals = flat_view(vec);
         all_vals |= ranges::action::sort;
         auto n_unique = ranges::distance(all_vals | ranges::view::unique);
         BOOST_TEST(n_unique == unique_total);
@@ -322,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_random_fill_2d)
 BOOST_AUTO_TEST_CASE(test_random_fill_3d)
 {
     std::mt19937 gen{1000003};
-    std::vector<std::vector<std::vector<std::uint64_t>>> vec =
+    std::vector<std::vector<std::vector<double>>> vec =
       {{{0, 0, 0}, {0, 0}, {0}}, {{0}, {0, 0}}};
 
     auto check = [](auto vec, std::vector<std::vector<long>> unique, long unique_total) {
@@ -334,7 +335,7 @@ BOOST_AUTO_TEST_CASE(test_random_fill_3d)
             }
         }
 
-        std::vector<std::uint64_t> all_vals = flat_view(vec);
+        std::vector<double> all_vals = flat_view(vec);
         all_vals |= ranges::action::sort;
         auto n_unique = ranges::distance(all_vals | ranges::view::unique);
         BOOST_TEST(n_unique == unique_total);


### PR DESCRIPTION
1. Add support for n-dimensional ranges to many vector utilities (instead of only n-dimensional `std::vectors`).
2. Improve `stream::random_fill` to support any n-dimensional range as a source.
3. Add support for random distributions to `stream::random_fill`.

Closes #16 