### PR TITLE
Add thread pool support to stream::buffer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ references:
       command: |
         apt-get update -qy
         apt -y install build-essential cmake clang \
-          libopencv-dev libboost-dev libboost-python-dev libboost-test-dev \
-          python3-dev python3-numpy
+          libopencv-dev libboost-dev libboost-python-dev libboost-system-dev \
+          libboost-thread-dev libboost-test-dev python3-dev python3-numpy
 
   ubuntu_install_tensorflow_cc: &ubuntu_install_tensorflow_cc
     run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,6 @@ endif()
 # Find Common Libraries
 # ---------------------
 
-find_package(Boost REQUIRED)
-
 if(BUILD_PYTHON)
   find_package(PythonInterp 3 REQUIRED)
   find_package(PythonLibs 3 REQUIRED)
@@ -75,6 +73,12 @@ if(BUILD_DOC)
   find_package(Doxygen REQUIRED)
 endif()
 
+if(BUILD_TEST)
+  find_package(Boost COMPONENTS system thread unit_test_framework REQUIRED)
+else()
+  find_package(Boost COMPONENTS system thread REQUIRED)
+endif()
+
 # ------------------
 # Build cxtream core
 # ------------------
@@ -89,6 +93,7 @@ target_compile_options(
 )
 target_link_libraries(
   cxtream_core INTERFACE
+  ${Boost_LIBRARIES}
   pthread
   stdc++fs
 )
@@ -129,12 +134,14 @@ if(BUILD_PYTHON)
     cxtream_python
     PUBLIC ${Boost_INCLUDE_DIRS}
     PUBLIC ${PYTHON_INCLUDE_DIRS}
+    PUBLIC ${BoostPython3_INCLUDE_DIRS}
   )
   target_link_libraries(
     cxtream_python
     cxtream_core
     ${Boost_LIBRARIES}
     ${PYTHON_LIBRARIES}
+    ${BoostPython3_LIBRARIES}
     stdc++fs
   )
   set_target_properties(
@@ -215,7 +222,6 @@ endif()
 # -----
 
 if(BUILD_TEST)
-  find_package(Boost COMPONENTS unit_test_framework REQUIRED)
   enable_testing()
   include("AddBoostTest")
   if(BUILD_PYTHON)

--- a/cmake/FindBoostPython3.cmake
+++ b/cmake/FindBoostPython3.cmake
@@ -34,6 +34,11 @@ while(NOT BoostPython3_FOUND)
 
 endwhile()
 
+if(BoostPython3_FOUND)
+  set(BoostPython3_LIBRARIES ${Boost_LIBRARIES})
+  set(BoostPython3_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   BoostPython3 DEFAULT_MSG

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -6,11 +6,11 @@ Requirements
 ---
 
 Officially supported systems are Ubuntu 16.10+ and Arch Linux, although __cxtream__ should
-work on any recent enough system. The __cxtream__ core is a header-only C++ library with
-dependencies to header-only parts of [Boost C++ Libraries](http://www.boost.org/)
+work on any recent enough system. The __cxtream__ core is a pure C++ library with a
+single dependency to [Boost C++ Libraries](http://www.boost.org/)
 (Boost 1.61+ is required).
 
-If you want to use __cxtream__ core only, install Boost via one of the following commands:
+If you want to use __cxtream core__ only, install Boost via one of the following commands:
 
 ```
 # Arch Linux
@@ -20,7 +20,7 @@ pacman -S boost
 apt install libboost-all-dev
 ```
 
-If you plan to use the Python bindings and OpenCV support,
+If you plan to use also the Python bindings with OpenCV support,
 use one of the following commands to install all the additional dependencies.
 
 ```

--- a/include/cxtream/core.hpp
+++ b/include/cxtream/core.hpp
@@ -16,6 +16,7 @@
 #include <cxtream/core/groups.hpp>
 #include <cxtream/core/index_mapper.hpp>
 #include <cxtream/core/stream.hpp>
+#include <cxtream/core/thread.hpp>
 #include <cxtream/core/utility.hpp>
 
 #endif

--- a/include/cxtream/core/stream/buffer.hpp
+++ b/include/cxtream/core/stream/buffer.hpp
@@ -66,7 +66,11 @@ private:
             fill_buffer();
         }
 
-        decltype(auto) read() const { return buffer_.front().get(); }
+        decltype(auto) read() const
+        {
+            return buffer_.front().get();
+        }
+
         bool equal(ranges::default_sentinel) const
         {
             return buffer_.empty() && it_ == ranges::end(rng_->rng_);

--- a/include/cxtream/core/stream/buffer.hpp
+++ b/include/cxtream/core/stream/buffer.hpp
@@ -10,6 +10,8 @@
 #ifndef CXTREAM_CORE_STREAM_BUFFER_HPP
 #define CXTREAM_CORE_STREAM_BUFFER_HPP
 
+#include <cxtream/core/thread.hpp>
+
 #include <range/v3/core.hpp>
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/view.hpp>
@@ -29,7 +31,6 @@ private:
 
     Rng rng_;
     std::size_t n_;
-    std::launch policy_;
 
     struct cursor {
     private:
@@ -37,7 +38,6 @@ private:
         ranges::iterator_t<Rng> it_ = {};
 
         std::size_t n_;
-        std::launch policy_;
         std::deque<std::shared_future<ranges::range_value_type_t<Rng>>> buffer_;
 
         void pop_buffer()
@@ -50,7 +50,8 @@ private:
         void fill_buffer()
         {
             while (it_ != ranges::end(rng_->rng_) && buffer_.size() < n_) {
-                buffer_.emplace_back(std::async(policy_, [it = it_]() { return *it; }));
+                auto task = [it = it_]() { return *it; };
+                buffer_.emplace_back(global_thread_pool.enqueue(std::move(task)));
                 ++it_;
             }
         }
@@ -61,7 +62,6 @@ private:
           : rng_{&rng}
           , it_{ranges::begin(rng.rng_)}
           , n_{rng.n_}
-          , policy_{rng.policy_}
         {
             fill_buffer();
         }
@@ -93,10 +93,9 @@ private:
 public:
     buffer_view() = default;
 
-    buffer_view(Rng rng, std::size_t n, std::launch policy)
+    buffer_view(Rng rng, std::size_t n)
       : rng_{rng}
       , n_{n}
-      , policy_{policy}
     {
     }
 
@@ -119,19 +118,17 @@ private:
     friend ranges::view::view_access;
     /// \endcond
 
-    static auto bind(buffer_fn buffer, std::size_t n = std::numeric_limits<std::size_t>::max(),
-                     std::launch policy = std::launch::async)
+    static auto bind(buffer_fn buffer, std::size_t n = std::numeric_limits<std::size_t>::max())
     {
-        return ranges::make_pipeable(std::bind(buffer, std::placeholders::_1, n, policy));
+        return ranges::make_pipeable(std::bind(buffer, std::placeholders::_1, n));
     }
 
 public:
     template<typename Rng, CONCEPT_REQUIRES_(ranges::ForwardRange<Rng>())>
     buffer_view<ranges::view::all_t<Rng>>
-    operator()(Rng&& rng, std::size_t n = std::numeric_limits<std::size_t>::max(),
-               std::launch policy = std::launch::async) const
+    operator()(Rng&& rng, std::size_t n = std::numeric_limits<std::size_t>::max()) const
     {
-        return {ranges::view::all(std::forward<Rng>(rng)), n, policy};
+        return {ranges::view::all(std::forward<Rng>(rng)), n};
     }
 };
 

--- a/include/cxtream/core/thread.hpp
+++ b/include/cxtream/core/thread.hpp
@@ -15,6 +15,7 @@
 #include <boost/thread/thread.hpp>
 
 #include <cmath>
+#include <functional>
 #include <future>
 #include <thread>
 #include <experimental/tuple>
@@ -51,16 +52,16 @@ public:
     ///
     /// \code
     ///     thread_pool tp{3};
-    ///     auto task = [](int i) { return i + 1; };
-    ///     std::future<int> f1 = tp.enqueue(task, 10);
-    ///     std::future<int> f2 = tp.enqueue(task, 11);
+    ///     auto fun = [](int i) { return i + 1; };
+    ///     std::future<int> f1 = tp.enqueue(fun, 10);
+    ///     std::future<int> f2 = tp.enqueue(fun, 11);
     ///     assert(f1.get() == 11);
     ///     assert(f2.get() == 12);
     /// \endcode
     ///
     /// \param fun The function to be executed.
-    /// \param args Parameters for the task. Note that they are taken by value.
-    /// \returns An std::future corresponding to the result of the task.
+    /// \param args Parameters for the function. Note that they are taken by value.
+    /// \returns An std::future corresponding to the result of the function call.
     template<typename Fun, typename... Args>
     std::future<std::result_of_t<Fun(Args...)>> enqueue(Fun fun, Args... args)
     {

--- a/include/cxtream/core/thread.hpp
+++ b/include/cxtream/core/thread.hpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+/// \defgroup Thread Multithreading.
+
+#ifndef CXTREAM_CORE_THREAD_HPP
+#define CXTREAM_CORE_THREAD_HPP
+
+#include <boost/asio.hpp>
+#include <boost/thread/thread.hpp>
+
+#include <cmath>
+#include <future>
+#include <thread>
+#include <experimental/tuple>
+
+namespace cxtream {
+
+/// \ingroup Thread
+/// \brief A simple thread pool class.
+///
+/// This class manages the given number of threads across which
+/// it automatically distributes the given tasks.
+class thread_pool {
+private:
+    boost::asio::io_service service_;
+    boost::asio::io_service::work work_{service_};
+    boost::thread_group threads_;
+
+public:
+
+    /// Spawn the given number of threads and start processing the queue.
+    ///
+    /// \param n_threads The number of threads to be spawned.
+    thread_pool(unsigned n_threads = std::thread::hardware_concurrency())
+    {
+        // always use at least a single thread
+        n_threads = std::max(1u, n_threads);
+        // populate the thread pool
+        for (unsigned i = 0; i < n_threads; ++i) {
+            threads_.create_thread([this]() { return this->service_.run(); });
+        }
+    }
+
+    /// Enqueue a function for processing.
+    ///
+    /// \code
+    ///     thread_pool tp{3};
+    ///     auto task = [](int i) { return i + 1; };
+    ///     std::future<int> f1 = tp.enqueue(task, 10);
+    ///     std::future<int> f2 = tp.enqueue(task, 11);
+    ///     assert(f1.get() == 11);
+    ///     assert(f2.get() == 12);
+    /// \endcode
+    ///
+    /// \param fun The function to be executed.
+    /// \param args Parameters for the task. Note that they are taken by value.
+    /// \returns An std::future corresponding to the result of the task.
+    template<typename Fun, typename... Args>
+    std::future<std::result_of_t<Fun(Args...)>> enqueue(Fun fun, Args... args)
+    {
+        using Ret = std::result_of_t<Fun(Args...)>;
+        std::packaged_task<Ret(Args...)> task{fun};
+        std::future<Ret> future = task.get_future();
+        // Packaged task is non-copyable, so ASIO's post() method cannot handle it.
+        // So we build a shared_ptr of the task and post a lambda
+        // dereferencing and running the task stored in the pointer.
+        auto shared_task = std::make_shared<std::packaged_task<Ret(Args...)>>(std::move(task));
+        auto shared_args = std::make_shared<std::tuple<Args...>>(std::move(args)...);
+        auto asio_task = [task = std::move(shared_task), args = std::move(shared_args)]() {
+            return std::experimental::apply(std::move(*task), std::move(*args));
+        };
+        service_.post(std::move(asio_task));
+        return future;
+    }
+};
+
+/// \ingroup Thread
+/// \brief Global thread pool object.
+///
+/// Prefer to use this object instead of spawning a new thread pool.
+static thread_pool global_thread_pool;
+
+} // namespace cxtream
+#endif

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -11,3 +11,5 @@ add_boost_test("test.core.dataframe" "dataframe.cpp" "")
 add_boost_test("test.core.groups" "groups.cpp" "")
 
 add_boost_test("test.core.index_mapper" "index_mapper.cpp" "")
+
+add_boost_test("test.core.thread" "thread.cpp" "")

--- a/test/core/thread.cpp
+++ b/test/core/thread.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *  cxtream library
+ *  Copyright (c) 2017, Cognexa Solutions s.r.o.
+ *  Author(s) Filip Matzner
+ *
+ *  This file is distributed under the MIT License.
+ *  See the accompanying file LICENSE.txt for the complete license agreement.
+ ****************************************************************************/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE thread_test
+
+#include <cxtream/core/thread.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <future>
+#include <memory>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+BOOST_AUTO_TEST_CASE(test_enqueue)
+{
+    cxtream::thread_pool tp{2};
+    std::vector<std::thread::id> ids(3);
+    auto task = [&ids](std::shared_ptr<int> ptr) {
+        // save the id of this thread
+        ids[*ptr] = std::this_thread::get_id();
+        // clone the given shared_ptr
+        std::shared_ptr<int> new_ptr{ptr};
+        // sleep so that tests have enough time to evaluate
+        std::this_thread::sleep_for(50ms);
+        return *new_ptr;
+    };
+    std::shared_ptr<int> ptr1 = std::make_shared<int>(0);
+    std::shared_ptr<int> ptr2 = std::make_shared<int>(1);
+    std::shared_ptr<int> ptr3 = std::make_shared<int>(2);
+
+    // run the tasks
+    std::future<int> f1 = tp.enqueue(task, ptr1);
+    std::future<int> f2 = tp.enqueue(task, ptr2);
+    std::future<int> f3 = tp.enqueue(task, ptr3);
+
+    // test that the processes run in parallel
+    std::this_thread::sleep_for(20ms);
+    // one reference to the pointer is held by this scope,
+    // other two are held by the task
+    BOOST_TEST(ptr1.use_count() == 3);
+    BOOST_TEST(ptr2.use_count() == 3);
+    // the third task should not be running yet, so
+    // one reference is held in this scope and one in the
+    // task queue 
+    BOOST_TEST(ptr3.use_count() == 2);
+    // now wait until the first two threads finish
+    BOOST_TEST(f1.get() == 0);
+    BOOST_TEST(f2.get() == 1);
+    // after reading their results, the third task should be running
+    std::this_thread::sleep_for(20ms);
+    BOOST_TEST(ptr3.use_count() == 3);
+    // and wait until it is finished
+    BOOST_TEST(f3.get() == 2);
+    
+    // make sure that exactly 2 threads were spawned
+    // (exactly one pair has to be the same)
+    BOOST_CHECK(ids[0] == ids[1] ^ ids[1] == ids[2] ^ ids[0] == ids[2]);
+}
+
+BOOST_AUTO_TEST_CASE(test_enqueue_move)
+{
+    // test that thread_pool.enqueue accepts move-only arguments
+    cxtream::thread_pool tp{2};
+    auto task = [](std::unique_ptr<int> ptr) { return *ptr; };
+    std::future<int> f = tp.enqueue(std::move(task), std::make_unique<int>(10));
+    BOOST_TEST(f.get() == 10);
+}

--- a/test/core/thread.cpp
+++ b/test/core/thread.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_enqueue)
     
     // make sure that exactly 2 threads were spawned
     // (exactly one pair has to be the same)
-    BOOST_CHECK(ids[0] == ids[1] ^ ids[1] == ids[2] ^ ids[0] == ids[2]);
+    BOOST_CHECK((ids[0] == ids[1]) ^ (ids[1] == ids[2]) ^ (ids[0] == ids[2]));
 }
 
 BOOST_AUTO_TEST_CASE(test_enqueue_move)


### PR DESCRIPTION
This PR also adds `cxtream::thread_pool` class and `cxtream::global_thread_pool` object which allows more general use of a common thread pool.

The only change that is not backwards compatible is that `stream::buffer` does not accept `std::launch` policy anymore (which was not really useful anyway).

This PR also solves OpenCV multithreading memory leaks https://github.com/opencv/opencv/issues/9745.