### PR TITLE
Reduce compilation time

### DIFF
--- a/cmake/build_config.hpp.in
+++ b/cmake/build_config.hpp.in
@@ -28,14 +28,4 @@
   #undef BUILD_TENSORFLOW
 #endif
 
-// only use mutable lambdas if the compiler is recent enough
-#if __GNUC__ >= 7
-// maybe clang will improve its support in the future,
-// then add `|| __clang_major__ >= 4` to the condition
-#define CXTREAM_MUTABLE_LAMBDA
-#define CXTREAM_MUTABLE_LAMBDA_V mutable
-#else
-#define CXTREAM_MUTABLE_LAMBDA_V
-#endif
-
 #endif

--- a/include/cxtream/core/stream/buffer.hpp
+++ b/include/cxtream/core/stream/buffer.hpp
@@ -134,6 +134,15 @@ public:
     {
         return {ranges::view::all(std::forward<Rng>(rng)), n};
     }
+
+    /// \cond
+    template<typename Rng, CONCEPT_REQUIRES_(!ranges::ForwardRange<Rng>())>
+    void operator()(Rng&&, std::size_t n = 0) const
+    {
+        CONCEPT_ASSERT_MSG(ranges::ForwardRange<Rng>(),
+          "stream::buffer only works on ranges satisfying the ForwardRange concept.");
+    }
+    /// \endcond
 };
 
 /// \ingroup Stream

--- a/include/cxtream/core/stream/column.hpp
+++ b/include/cxtream/core/stream/column.hpp
@@ -27,6 +27,9 @@ private:
 
 public:
 
+    using batch_type = std::vector<T>;
+    using value_type = T;
+
     // constructors //
 
     column_base() = default;

--- a/include/cxtream/core/stream/column.hpp
+++ b/include/cxtream/core/stream/column.hpp
@@ -28,7 +28,7 @@ private:
 public:
 
     using batch_type = std::vector<T>;
-    using value_type = T;
+    using example_type = T;
 
     // constructors //
 

--- a/include/cxtream/core/stream/drop.hpp
+++ b/include/cxtream/core/stream/drop.hpp
@@ -16,13 +16,52 @@
 
 namespace cxtream::stream {
 
-template<typename... Columns>
-constexpr auto drop_fn()
-{
-    return ranges::view::transform([](auto&& source) {
-        return utility::tuple_remove<Columns...>(std::forward<decltype(source)>(source));
-    });
-}
+namespace detail {
+
+    template<typename Source, typename... DropColumns>
+    struct drop_impl;
+
+    template<typename... SourceColumns, typename... DropColumns>
+    struct drop_impl<std::tuple<SourceColumns...>, DropColumns...> {
+
+        constexpr decltype(auto) operator()(std::tuple<SourceColumns...> source) const
+        {
+            return utility::tuple_remove<DropColumns...>(std::move(source));
+        }
+
+    };
+
+    template<typename... Columns>
+    class drop_fn {
+    private:
+        friend ranges::view::view_access;
+
+        static auto bind(drop_fn<Columns...> fun)
+        {
+            return ranges::make_pipeable(std::bind(fun, std::placeholders::_1));
+        }
+
+    public:
+        template<typename Rng, CONCEPT_REQUIRES_(ranges::ForwardRange<Rng>())>
+        constexpr auto operator()(Rng&& rng) const
+        {
+            using StreamType = ranges::range_value_type_t<Rng>;
+            return ranges::view::transform(
+              std::forward<Rng>(rng),
+              drop_impl<StreamType, Columns...>{});
+        }
+
+        /// \cond
+        template<typename Rng, CONCEPT_REQUIRES_(!ranges::ForwardRange<Rng>())>
+        void operator()(Rng&&) const
+        {
+            CONCEPT_ASSERT_MSG(ranges::ForwardRange<Rng>(),
+              "stream::drop only works on ranges satisfying the ForwardRange concept.");
+        }
+        /// \endcond
+    };
+
+}  // namespace detail
 
 /// \ingroup Stream
 /// \brief Drops columns from a stream.
@@ -35,7 +74,7 @@ constexpr auto drop_fn()
 ///     auto rng = data | create<id, value>() | drop<id>;
 /// \endcode
 template <typename... Columns>
-auto drop = drop_fn<Columns...>();
+constexpr ranges::view::view<detail::drop_fn<Columns...>> drop{};
 
 }  // end namespace cxtream::stream
 #endif

--- a/include/cxtream/core/stream/filter.hpp
+++ b/include/cxtream/core/stream/filter.hpp
@@ -43,7 +43,7 @@ namespace detail {
                 ranges::view::zip(cols...)
               | ranges::view::filter([this](const auto& tuple) -> bool {
                     auto slice_view = utility::tuple_index_view<ByIdxs...>(tuple);
-                    return std::experimental::apply(this->fun, std::move(slice_view));
+                    return boost::hana::unpack(std::move(slice_view), this->fun);
                 })
               | ranges::view::move;
             return utility::maybe_untuple(utility::unzip(std::move(range_of_tuples)));
@@ -65,7 +65,7 @@ namespace detail {
             auto proj = [](auto& column) { return std::ref(column.value()); };
             auto slice_view = utility::tuple_type_view<ByColumns...>(tuple);
             auto values = utility::tuple_transform(std::move(slice_view), std::move(proj));
-            return std::experimental::apply(fun, std::move(values));
+            return boost::hana::unpack(std::move(values), fun);
         }
     };
 

--- a/include/cxtream/core/stream/filter.hpp
+++ b/include/cxtream/core/stream/filter.hpp
@@ -37,7 +37,7 @@ namespace detail {
         Fun fun;
 
         // Properly zips/unzips the data and applies the filter function.
-        constexpr utility::maybe_tuple<FromTypes...> operator()(FromTypes&... cols) const
+        constexpr utility::maybe_tuple<FromTypes...> operator()(FromTypes&... cols)
         {
             auto range_of_tuples =
                 ranges::view::zip(cols...)
@@ -60,7 +60,7 @@ namespace detail {
         Fun fun;
 
         template<typename... SourceColumns>
-        constexpr bool operator()(const std::tuple<SourceColumns...>& tuple) const
+        constexpr bool operator()(const std::tuple<SourceColumns...>& tuple)
         {
             auto proj = [](auto& column) { return std::ref(column.value()); };
             auto slice_view = utility::tuple_type_view<ByColumns...>(tuple);

--- a/include/cxtream/core/stream/for_each.hpp
+++ b/include/cxtream/core/stream/for_each.hpp
@@ -24,7 +24,7 @@ namespace detail {
     struct wrap_void_fun_for_transform {
         Fun fun;
 
-        constexpr utility::maybe_tuple<FromTypes...> operator()(FromTypes&... args) const
+        constexpr utility::maybe_tuple<FromTypes...> operator()(FromTypes&... args)
         {
             std::invoke(fun, args...);
             // we can force std::move here because the old

--- a/include/cxtream/core/stream/transform.hpp
+++ b/include/cxtream/core/stream/transform.hpp
@@ -39,7 +39,7 @@ namespace detail {
         Projection proj;
 
         template<typename... SourceTypes>
-        constexpr auto operator()(std::tuple<SourceTypes...> source) const
+        constexpr auto operator()(std::tuple<SourceTypes...> source)
         {
             // build the view for the transformer, i.e., slice and project
             auto slice_view =
@@ -99,17 +99,17 @@ namespace detail {
              typename... FromTypes, typename... ToTypes>
     struct wrap_fun_for_dim<Fun, Dim, NOuts, from_t<FromTypes...>, to_t<ToTypes...>> {
         Fun fun;
-        using FunRef = decltype(std::cref(fun));
+        using FunRef = decltype(std::ref(fun));
 
         constexpr utility::maybe_tuple<ToTypes...>
-        operator()(std::tuple<FromTypes&...> tuple_of_ranges) const
+        operator()(std::tuple<FromTypes&...> tuple_of_ranges)
         {
             assert(utility::same_size(tuple_of_ranges));
             // build the function to be applied
             wrap_fun_for_dim<FunRef, Dim-1, NOuts,
               from_t<ranges::range_value_type_t<FromTypes>...>,
               to_t<ranges::range_value_type_t<ToTypes>...>>
-                fun_wrapper{std::cref(fun)};
+                fun_wrapper{std::ref(fun)};
             // transform
             auto range_of_tuples =
                 std::experimental::apply(ranges::view::zip, std::move(tuple_of_ranges))
@@ -123,7 +123,7 @@ namespace detail {
         Fun fun;
 
         constexpr utility::maybe_tuple<ToTypes...>
-        operator()(std::tuple<FromTypes&...> tuple) const
+        operator()(std::tuple<FromTypes&...> tuple)
         {
             return std::experimental::apply(fun, std::move(tuple));
         }
@@ -184,7 +184,7 @@ namespace detail {
                               from_t<CondCol, Cols...>, to_t<ToTypes...>> {
         Fun fun;
 
-        constexpr utility::maybe_tuple<ToTypes...> operator()(CondCol& cond, Cols&... cols) const
+        constexpr utility::maybe_tuple<ToTypes...> operator()(CondCol& cond, Cols&... cols)
         {
             // make a tuple of all arguments, except for the condition
             std::tuple<Cols&...> args_view{cols...};
@@ -310,7 +310,7 @@ namespace detail {
         std::reference_wrapper<Prng> prng;
         const double prob;
 
-        utility::maybe_tuple<ToTypes...> operator()(FromTypes&... cols) const
+        utility::maybe_tuple<ToTypes...> operator()(FromTypes&... cols)
         {
             assert(prob >= 0. && prob <= 1.);
             std::uniform_real_distribution<> dis{0, 1};

--- a/include/cxtream/core/stream/transform.hpp
+++ b/include/cxtream/core/stream/transform.hpp
@@ -114,7 +114,7 @@ namespace detail {
                 fun_wrapper{std::ref(fun)};
             // transform
             auto range_of_tuples =
-                std::experimental::apply(ranges::view::zip, std::move(tuple_of_ranges))
+                boost::hana::unpack(std::move(tuple_of_ranges), ranges::view::zip)
               | ranges::view::transform(std::move(fun_wrapper));
             return utility::unzip_if<(NOuts > 1)>(std::move(range_of_tuples));
         }
@@ -127,7 +127,7 @@ namespace detail {
         constexpr utility::maybe_tuple<ToTypes...>
         operator()(std::tuple<FromTypes&...> tuple)
         {
-            return std::experimental::apply(fun, std::move(tuple));
+            return boost::hana::unpack(std::move(tuple), fun);
         }
     };
 
@@ -194,8 +194,8 @@ namespace detail {
             if (cond) {
                 // the function is applied only on a subset of the arguments
                 // representing FromColumns
-                return std::experimental::apply(fun,
-                  utility::tuple_index_view(args_view, FromIdxs{}));
+                return boost::hana::unpack(
+                  utility::tuple_index_view(args_view, FromIdxs{}), fun);
             }
             // return the original arguments if the condition is false
             // only a subset of the arguments representing ToColumns is returned
@@ -322,8 +322,8 @@ namespace detail {
             if (prob == 1. || (prob > 0. && dis(prng.get()) < prob)) {
                 // the function is applied only on a subset of the arguments
                 // representing FromColumns
-                return std::experimental::apply(fun,
-                  utility::tuple_index_view(args_view, FromIdxs{}));
+                return boost::hana::unpack(
+                  utility::tuple_index_view(args_view, FromIdxs{}), fun);
             }
             // return the original arguments if the dice roll fails
             // only a subset of the arguments representing ToColumns is returned

--- a/include/cxtream/core/stream/transform.hpp
+++ b/include/cxtream/core/stream/transform.hpp
@@ -50,33 +50,41 @@ constexpr auto partial_transform(from_t<FromTypes...>, to_t<ToTypes...>,
 
 namespace detail {
 
-    // apply fun to each element in tuple of ranges in the given dimension
-    template<std::size_t Dim, std::size_t NOuts>
-    struct wrap_fun_for_dim
-    {
-        template<typename Fun>
-        static constexpr auto impl(Fun fun)
+    // Apply fun to each element in tuple of ranges in the given dimension.
+    template<typename Fun, std::size_t Dim, std::size_t NOuts, typename From, typename To>
+    struct wrap_fun_for_dim;
+
+    template<typename Fun, std::size_t Dim, std::size_t NOuts,
+             typename... FromTypes, typename... ToTypes>
+    struct wrap_fun_for_dim<Fun, Dim, NOuts, from_t<FromTypes...>, to_t<ToTypes...>> {
+        Fun fun;
+        using FunRef = decltype(std::cref(fun));
+
+        constexpr utility::maybe_tuple<ToTypes...>
+        operator()(std::tuple<FromTypes&...> tuple_of_ranges) const
         {
-            return [fun = std::move(fun)](auto&& tuple_of_ranges) CXTREAM_MUTABLE_LAMBDA_V {
-                assert(utility::same_size(tuple_of_ranges));
-                auto range_of_tuples =
-                  std::experimental::apply(ranges::view::zip,
-                                           std::forward<decltype(tuple_of_ranges)>(tuple_of_ranges))
-                  | ranges::view::transform(wrap_fun_for_dim<Dim-1, NOuts>::impl(fun));
-                return utility::unzip_if<(NOuts > 1)>(std::move(range_of_tuples));
-            };
+            assert(utility::same_size(tuple_of_ranges));
+            // build the function to be applied
+            wrap_fun_for_dim<FunRef, Dim-1, NOuts,
+              from_t<ranges::range_value_type_t<FromTypes>...>,
+              to_t<ranges::range_value_type_t<ToTypes>...>>
+                fun_wrapper{std::cref(fun)};
+            // transform
+            auto range_of_tuples =
+                std::experimental::apply(ranges::view::zip, std::move(tuple_of_ranges))
+              | ranges::view::transform(std::move(fun_wrapper));
+            return utility::unzip_if<(NOuts > 1)>(std::move(range_of_tuples));
         }
     };
 
-    template<std::size_t NOuts>
-    struct wrap_fun_for_dim<0, NOuts>
-    {
-        template<typename Fun>
-        static constexpr auto impl(Fun fun)
+    template<typename Fun, std::size_t NOuts, typename... FromTypes, typename... ToTypes>
+    struct wrap_fun_for_dim<Fun, 0, NOuts, from_t<FromTypes...>, to_t<ToTypes...>> {
+        Fun fun;
+
+        constexpr utility::maybe_tuple<ToTypes...>
+        operator()(std::tuple<FromTypes&...> tuple) const
         {
-            return [fun = std::move(fun)](auto&& tuple) CXTREAM_MUTABLE_LAMBDA_V {
-                return std::experimental::apply(fun, std::forward<decltype(tuple)>(tuple));
-            };
+            return std::experimental::apply(fun, std::move(tuple));
         }
     };
 
@@ -111,73 +119,46 @@ constexpr auto transform(from_t<FromColumns...> f,
                          dim_t<Dim> d = dim_t<1>{})
 {
     // wrap the function to be applied in the appropriate dimension
-    auto fun_wrapper = detail::wrap_fun_for_dim<Dim, sizeof...(ToColumns)>::impl(std::move(fun));
+    detail::wrap_fun_for_dim<
+      Fun, Dim, sizeof...(ToColumns),
+      from_t<typename FromColumns::batch_type...>,
+      to_t<typename ToColumns::batch_type...>>
+      fun_wrapper{std::move(fun)};
 
-    return stream::partial_transform(f, t, std::move(fun_wrapper),
-                                     [](auto& column) { return std::ref(column.value()); });
+    auto proj = [](auto& column) { return std::ref(column.value()); };
+    return stream::partial_transform(f, t, std::move(fun_wrapper), std::move(proj));
 }
 
 // conditional transform //
 
 namespace detail {
 
-    // This function accepts a tuple of references and returns a new tuple
-    // made by moving the values from the original tuple.
-    // If the tuple is of size 1, then it only returns the rvalue
-    // of its element (without wrapping it in a tuple).
-    // Furthermore, one can specify which elements should be taken
-    // using std::index_sequence.
-    template<std::size_t NArgs>
-    struct move_to_maybe_make_tuple
-    {
-        template<typename Tuple, std::size_t... Is>
-        static constexpr auto impl(Tuple& tuple, std::index_sequence<Is...>)
-        {
-            return std::make_tuple(std::move(std::get<Is>(tuple))...);
-        }
-    };
-
-    template<>
-    struct move_to_maybe_make_tuple<1>
-    {
-        template<typename Tuple, std::size_t I>
-        static constexpr auto impl(Tuple& tuple, std::index_sequence<I>)
-        {
-            return std::move(std::get<I>(tuple));
-        }
-    };
-
     // wrap the function to be applied only on if the first argument evaluates to true
-    template<std::size_t NOuts>
-    struct wrap_fun_with_cond
-    {
-        template<
-          typename Fun,
-          std::size_t... FromIndices,
-          std::size_t... ToIndices>
-        static constexpr auto impl(
-          Fun fun,
-          std::index_sequence<FromIndices...> from_indices,
-          std::index_sequence<ToIndices...> to_indices)
+    template<typename Fun, typename FromIdxs, typename ToIdxs, typename From, typename To>
+    struct wrap_fun_with_cond;
+
+    template<typename Fun, typename FromIdxs, std::size_t... ToIdxs,
+             typename CondCol, typename... Cols, typename... ToTypes>
+    struct wrap_fun_with_cond<Fun, FromIdxs, std::index_sequence<ToIdxs...>,
+                              from_t<CondCol, Cols...>, to_t<ToTypes...>> {
+        Fun fun;
+
+        constexpr utility::maybe_tuple<ToTypes...> operator()(CondCol& cond, Cols&... cols) const
         {
-            return [fun = std::move(fun), to_indices]
-              (auto cond, auto&... cols) CXTREAM_MUTABLE_LAMBDA_V {
-                // make a tuple of all arguments, except for the condition
-                auto args_view = std::forward_as_tuple<decltype(cols)...>(cols...);
-                // apply the function if the condition is true
-                if (cond) {
-                    // the function is applied only on a subset of the arguments
-                    // representing FromColumns
-                    return std::experimental::apply(fun,
-                      utility::tuple_index_view<FromIndices...>(args_view));
-                // return the original arguments if the condition is false
-                } else {
-                    // only a subset of the arguments representing ToColumns is returned
-                    // note: We can force std::move in here, because
-                    // we are only copying data to themselves.
-                    return move_to_maybe_make_tuple<NOuts>::impl(args_view, to_indices);
-                }
-            };
+            // make a tuple of all arguments, except for the condition
+            std::tuple<Cols&...> args_view{cols...};
+            // apply the function if the condition is true
+            if (cond) {
+                // the function is applied only on a subset of the arguments
+                // representing FromColumns
+                return std::experimental::apply(fun,
+                  utility::tuple_index_view(args_view, FromIdxs{}));
+            }
+            // return the original arguments if the condition is false
+            // only a subset of the arguments representing ToColumns is returned
+            // note: We can force std::move in here, because
+            // we are only copying data to themselves.
+            return {std::move(std::get<ToIdxs>(args_view))...};
         }
     };
 
@@ -250,17 +231,22 @@ constexpr auto transform(
     // are concatenated in a single tuple
     constexpr std::size_t n_from = sizeof...(FromColumns);
     constexpr std::size_t n_to = sizeof...(ToColumns);
-    std::make_index_sequence<n_from> from_indices;
-    utility::make_offset_index_sequence<n_from, n_to> to_indices;
+    using FromIdxs = std::make_index_sequence<n_from>;
+    using ToIdxs = utility::make_offset_index_sequence<n_from, n_to>;
 
     // wrap the function to be applied in the appropriate dimension using the condition column
-    auto prob_fun =
-      detail::wrap_fun_with_cond<n_to>::impl(std::move(fun), from_indices, to_indices);
+    detail::wrap_fun_with_cond<
+      Fun, FromIdxs, ToIdxs,
+      from_t<utility::ndim_type_t<typename CondColumn::batch_type, Dim>,
+             utility::ndim_type_t<typename FromColumns::batch_type, Dim>...,
+             utility::ndim_type_t<typename ToColumns::batch_type, Dim>...>,
+      to_t<utility::ndim_type_t<typename ToColumns::batch_type, Dim>...>>
+      cond_fun{std::move(fun)};
 
     // transform from both, FromColumns and ToColumns into ToColumns
     // the wrapper function takes care of extracting the parameters for the original function
     return stream::transform(from_t<CondColumn, FromColumns..., ToColumns...>{},
-                             t, std::move(prob_fun), d);
+                             t, std::move(cond_fun), d);
 }
 
 // probabilistic transform //
@@ -268,40 +254,39 @@ constexpr auto transform(
 namespace detail {
 
     // wrap the function to be an identity if the dice roll fails
-    template<std::size_t NOuts>
-    struct wrap_fun_with_prob
-    {
-        template<
-          typename Fun,
-          typename Prng,
-          std::size_t... FromIndices,
-          std::size_t... ToIndices>
-        static constexpr auto impl(
-          double prob,
-          Fun fun,
-          Prng& prng,
-          std::index_sequence<FromIndices...> from_indices,
-          std::index_sequence<ToIndices...> to_indices)
+    template<typename Fun, typename Prng,
+             typename FromIdxs, typename ToIdxs,
+             typename From, typename To>
+    struct wrap_fun_with_prob;
+
+    template<typename Fun, typename Prng,
+             typename FromIdxs, std::size_t... ToIdxs,
+             typename... FromTypes, typename... ToTypes>
+    struct wrap_fun_with_prob<Fun, Prng,
+                              FromIdxs, std::index_sequence<ToIdxs...>,
+                              from_t<FromTypes...>, to_t<ToTypes...>> {
+        Fun fun;
+        std::reference_wrapper<Prng> prng;
+        const double prob;
+
+        utility::maybe_tuple<ToTypes...> operator()(FromTypes&... cols) const
         {
-            return [fun = std::move(fun), &prng, prob, to_indices]
-              (auto&... cols) CXTREAM_MUTABLE_LAMBDA_V {
-                std::uniform_real_distribution<> dis(0, 1);
-                // make a tuple of all arguments
-                auto args_view = std::forward_as_tuple<decltype(cols)...>(cols...);
-                // apply the function if the dice roll succeeds
-                if (prob == 1. || (prob > 0. && dis(prng) < prob)) {
-                    // the function is applied only on a subset of the arguments
-                    // representing FromColumns
-                    return std::experimental::apply(fun,
-                      utility::tuple_index_view<FromIndices...>(args_view));
-                // return the original arguments if the dice roll fails
-                } else {
-                    // only a subset of the arguments representing ToColumns is returned
-                    // note: We can force std::move in here, because
-                    // we are only copying data to themselves.
-                    return move_to_maybe_make_tuple<NOuts>::impl(args_view, to_indices);
-                }
-            };
+            assert(prob >= 0. && prob <= 1.);
+            std::uniform_real_distribution<> dis{0, 1};
+            // make a tuple of all arguments
+            std::tuple<FromTypes&...> args_view{cols...};
+            // apply the function if the dice roll succeeds
+            if (prob == 1. || (prob > 0. && dis(prng.get()) < prob)) {
+                // the function is applied only on a subset of the arguments
+                // representing FromColumns
+                return std::experimental::apply(fun,
+                  utility::tuple_index_view(args_view, FromIdxs{}));
+            }
+            // return the original arguments if the dice roll fails
+            // only a subset of the arguments representing ToColumns is returned
+            // note: We can force std::move in here, because
+            // we are only copying data to themselves.
+            return {std::move(std::get<ToIdxs>(args_view))...};
         }
     };
 
@@ -356,12 +341,16 @@ constexpr auto transform(
     // are concatenated in a single tuple
     constexpr std::size_t n_from = sizeof...(FromColumns);
     constexpr std::size_t n_to = sizeof...(ToColumns);
-    std::make_index_sequence<n_from> from_indices;
-    utility::make_offset_index_sequence<n_from, n_to> to_indices;
+    using FromIdxs = std::make_index_sequence<n_from>;
+    using ToIdxs = utility::make_offset_index_sequence<n_from, n_to>;
 
     // wrap the function to be applied in the appropriate dimension with the given probabiliy
-    auto prob_fun = detail::wrap_fun_with_prob<n_to>::impl(
-      prob, std::move(fun), prng, from_indices, to_indices);
+    detail::wrap_fun_with_prob<
+      Fun, Prng, FromIdxs, ToIdxs,
+      from_t<utility::ndim_type_t<typename FromColumns::batch_type, Dim>...,
+             utility::ndim_type_t<typename ToColumns::batch_type, Dim>...>,
+      to_t<utility::ndim_type_t<typename ToColumns::batch_type, Dim>...>>
+      prob_fun{std::move(fun), prng, prob};
 
     // transform from both, FromColumns and ToColumns into ToColumns
     // the wrapper function takes care of extracting the parameters for the original function

--- a/include/cxtream/core/thread.hpp
+++ b/include/cxtream/core/thread.hpp
@@ -12,6 +12,7 @@
 #define CXTREAM_CORE_THREAD_HPP
 
 #include <boost/asio.hpp>
+#include <boost/hana.hpp>
 #include <boost/thread/thread.hpp>
 
 #include <cmath>
@@ -19,7 +20,6 @@
 #include <future>
 #include <experimental/optional>
 #include <thread>
-#include <experimental/tuple>
 
 namespace cxtream {
 
@@ -73,9 +73,9 @@ public:
         // So we build a shared_ptr of the task and post a lambda
         // dereferencing and running the task stored in the pointer.
         auto shared_task = std::make_shared<std::packaged_task<Ret(Args...)>>(std::move(task));
-        auto shared_args = std::make_shared<std::tuple<Args...>>(std::move(args)...);
+        auto shared_args = std::make_shared<boost::hana::tuple<Args...>>(std::move(args)...);
         auto asio_task = [task = std::move(shared_task), args = std::move(shared_args)]() {
-            return std::experimental::apply(std::move(*task), std::move(*args));
+            return boost::hana::unpack(std::move(*args), std::move(*task));
         };
         service_.post(std::move(asio_task));
         return future;

--- a/include/cxtream/core/utility/tuple.hpp
+++ b/include/cxtream/core/utility/tuple.hpp
@@ -521,7 +521,7 @@ namespace detail {
 template<typename Tuple>
 decltype(auto) maybe_untuple(Tuple&& tuple)
 {
-    constexpr std::size_t tuple_size = std::tuple_size<std::decay_t<Tuple>>{};
+    constexpr std::size_t tuple_size = std::tuple_size<std::decay_t<Tuple>>::value;
     return detail::maybe_untuple_impl<tuple_size>::impl(std::forward<Tuple>(tuple));
 }
 

--- a/include/cxtream/core/utility/tuple.hpp
+++ b/include/cxtream/core/utility/tuple.hpp
@@ -173,13 +173,14 @@ constexpr auto tuple_type_view(Tuple& tuple)
 /// \code
 ///     auto tpl = std::make_tuple(0, 5., 'c');
 ///     auto subtpl = tuple_index_view<2, 0>(t1);
+///     // or equivalently: auto subtpl = tuple_index_view(t1, std::index_sequence<2, 0>{});
 ///     static_assert(std::is_same<std::tuple<char&, int&>, decltype(subtpl)>{});
 ///     assert(subtpl == std::tuple<char, int>{'c', 0});
 /// \endcode
 ///
 /// \returns The view of the original tuple.
 template<std::size_t... Idxs, typename Tuple>
-constexpr auto tuple_index_view(Tuple& tuple)
+constexpr auto tuple_index_view(Tuple& tuple, std::index_sequence<Idxs...> = {})
 {
     return std::make_tuple(std::ref(std::get<Idxs>(tuple))...);
 }

--- a/include/cxtream/core/utility/vector.hpp
+++ b/include/cxtream/core/utility/vector.hpp
@@ -61,7 +61,7 @@ struct ndims<T, true>
 ///
 /// Example:
 /// \code
-///     using rng_type = ndim_type<std::vector<std::list<int>>>::type;
+///     using rng_type = ndim_type_t<std::vector<std::list<int>>>;
 ///     // rng_type is int
 ///     using rng1_type = ndim_type<std::list<std::vector<int>>, 1>::type;
 ///     // rng1_type is std::vector<int>
@@ -83,6 +83,10 @@ template<typename Rng>
 struct ndim_type<Rng, -1L>
   : ndim_type<Rng, ndims<Rng>{}> {
 };
+
+/// Template alias for quick access to ndim_type<>::type.
+template<typename T, long Dim = -1L>
+using ndim_type_t = typename ndim_type<T, Dim>::type;
 
 // multidimensional range size //
 
@@ -202,7 +206,7 @@ namespace detail {
 /// \param vec_size The requested size created by ndim_size.
 /// \param val The value to pad with.
 /// \returns The reference to the given vector after resizing.
-template<typename T, typename ValT = typename ndim_type<std::vector<T>>::type>
+template<typename T, typename ValT = ndim_type_t<std::vector<T>>>
 std::vector<T>& ndim_resize(std::vector<T>& vec,
                             const std::vector<std::vector<long>>& vec_size,
                             ValT val = ValT{})

--- a/test/core/stream/buffer.cpp
+++ b/test/core/stream/buffer.cpp
@@ -13,6 +13,7 @@
 #include "../common.hpp"
 
 #include <cxtream/core/stream/buffer.hpp>
+#include <cxtream/core/stream/transform.hpp>
 
 #include <boost/test/unit_test.hpp>
 #include <range/v3/view/indirect.hpp>
@@ -136,4 +137,18 @@ BOOST_AUTO_TEST_CASE(test_buffer_whole_range)
     BOOST_CHECK(it == ranges::end(rng));
     std::this_thread::sleep_for(20ms);
     test_use_count(data, {1, 1, 1, 1, 1});
+}
+
+BOOST_AUTO_TEST_CASE(test_buffer_transformed_stream)
+{
+    std::vector<std::tuple<Int, Double>> data = {{{3, 7}, {5., 1.}}, {1, 2.}};
+
+    auto generated = data
+      | transform(from<Int, Double>, to<Double>, [](int i, double d) {
+            return (double)(i + d);
+        })
+      | buffer(3);
+
+    std::vector<std::tuple<Double, Int>> desired = {{{3 + 5., 7 + 1.}, {3, 7}}, {1 + 2., 1}};
+    test_ranges_equal(generated, desired);
 }

--- a/test/core/stream/filter1.cpp
+++ b/test/core/stream/filter1.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_dim1)
     std::size_t i = 0;
     data
       | create<Int, Double>(2)
-      | filter(from<Int, Double>, by<Double>, [](double v) { return v >= 5.; }, dim<1>)
+      | filter(from<Int, Double>, by<Double>, [](double v) { return v >= 5.; })
       | for_each(from<Int, Double>, [&i](auto& ints, auto& doubles) {
             switch (i++) {
             case 0: BOOST_TEST(ints    == (std::vector<int>{3}));
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_dim1_partial)
     std::size_t i = 0;
     data
       | create<Int, Double>(2)
-      | filter(from<Double>, by<Double>, [](double v) { return v >= 5.; }, dim<1>)
+      | filter(from<Double>, by<Double>, [](double v) { return v >= 5.; })
       | for_each(from<Int, Double>, [&i](auto& a, auto& b) {
             switch (i++) {
             case 0: BOOST_CHECK(a == (std::vector<int>{3, 1}));
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(test_dim1_move_only)
     std::size_t i = 0;
     data
       | ranges::view::move
-      | filter(from<Unique>, by<Unique>, [](auto& ptr) { return *ptr >= 5.; }, dim<1>)
+      | filter(from<Unique>, by<Unique>, [](auto& ptr) { return *ptr >= 5.; })
       | for_each(from<Int, Unique>, [&i](auto& a, auto& b) {
             switch (i++) {
             case 0: BOOST_CHECK(a == (std::vector<int>{3}));

--- a/test/core/stream/filter2.cpp
+++ b/test/core/stream/filter2.cpp
@@ -14,6 +14,30 @@
 
 using namespace cxtream::stream;
 
+BOOST_AUTO_TEST_CASE(test_mutable)
+{
+    CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)
+    const std::vector<std::tuple<int, std::vector<int>>> data = {
+      {{3, {1, 5}}, {1, {2, 4}}, {2, {7, 1}}, {6, {3, 5}}}};
+
+    std::size_t i = 0;
+    auto generated = data
+      | create<Int, IntVec>(2)
+      | filter(from<Int, IntVec>, by<Int>, [i = 0](int v) mutable { return i++ % 2 == 0; })
+      | for_each(from<Int, IntVec>, [&i](auto& ints, auto& intvecs) {
+            switch (i++) {
+            case 0: BOOST_TEST(ints    == (std::vector<int>{3}));
+                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{1, 5}}));
+                    break;
+            case 1: BOOST_TEST(ints    == (std::vector<int>{2}));
+                    BOOST_TEST(intvecs == (std::vector<std::vector<int>>{{7, 1}}));
+                    break;
+            }
+        }, dim<0>)
+      | ranges::to_vector;
+    BOOST_TEST(i == 2);
+}
+
 BOOST_AUTO_TEST_CASE(test_dim2_partial)
 {
     CXTREAM_DEFINE_COLUMN(IntVec, std::vector<int>)

--- a/test/core/stream/for_each.cpp
+++ b/test/core/stream/for_each.cpp
@@ -42,7 +42,6 @@ BOOST_AUTO_TEST_CASE(test_for_each_of_two)
 
 BOOST_AUTO_TEST_CASE(test_for_each_mutable)
 {
-#ifdef CXTREAM_MUTABLE_LAMBDA
     std::vector<std::tuple<Int>> data = {{{1, 3}}, {{5, 7}}};
     struct {
         int i = 0;
@@ -53,10 +52,7 @@ BOOST_AUTO_TEST_CASE(test_for_each_mutable)
     auto generated = data
       | for_each(from<Int>, func)
       | ranges::to_vector;
-    BOOST_TEST(*(func.i_ptr) == 2);
-#else
-    BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
-#endif
+    BOOST_TEST(*(func.i_ptr) == 4);
 }
 
 BOOST_AUTO_TEST_CASE(test_for_each_move_only)
@@ -117,7 +113,6 @@ BOOST_AUTO_TEST_CASE(test_for_each_dim2_move_only)
 
 BOOST_AUTO_TEST_CASE(test_for_each_dim2_move_only_mutable)
 {
-#ifdef CXTREAM_MUTABLE_LAMBDA
     auto data = generate_move_only_data();
 
     std::vector<int> generated;
@@ -130,9 +125,6 @@ BOOST_AUTO_TEST_CASE(test_for_each_dim2_move_only_mutable)
           }, dim<2>)
       | ranges::to_vector;
 
-    std::vector<int> desired = {4, 5, 4, 5, 4, 5};
+    std::vector<int> desired = {4, 5, 6, 7, 8, 9};
     BOOST_CHECK(generated == desired);
-#else
-    BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
-#endif
 }

--- a/test/core/stream/for_each.cpp
+++ b/test/core/stream/for_each.cpp
@@ -26,40 +26,6 @@
 
 using namespace cxtream::stream;
 
-BOOST_AUTO_TEST_CASE(test_partial_for_each)
-{
-    // partial_for_each
-    std::vector<int> generated;
-  
-    ranges::view::iota(1, 5)
-      | ranges::view::transform(std::make_tuple<int>)
-      | partial_for_each(from<int>, [&generated](const std::tuple<int> &t) {
-            generated.push_back(std::get<0>(t));
-            return 42;
-        })
-      | ranges::to_vector;
-  
-    test_ranges_equal(generated, ranges::view::iota(1, 5));
-}
-
-BOOST_AUTO_TEST_CASE(test_partial_for_each_move_only)
-{
-    // partial_for_each of a move-only column
-    std::vector<int> generated;
-  
-    ranges::view::iota(1, 5)
-      | ranges::view::transform([](int i) {
-            return std::make_tuple(std::make_unique<int>(i));
-        })
-      | partial_for_each(from<std::unique_ptr<int>>,
-          [&generated](const std::tuple<std::unique_ptr<int>&>& t) {
-              generated.push_back(*std::get<0>(t));
-        })
-      | ranges::to_vector;
-  
-    test_ranges_equal(generated, ranges::view::iota(1, 5));
-}
-
 BOOST_AUTO_TEST_CASE(test_for_each_of_two)
 {
     // for_each of two columns

--- a/test/core/stream/transform1.cpp
+++ b/test/core/stream/transform1.cpp
@@ -73,7 +73,6 @@ BOOST_AUTO_TEST_CASE(test_move_only)
 
 BOOST_AUTO_TEST_CASE(test_mutable)
 {
-#ifdef CXTREAM_MUTABLE_LAMBDA
     std::vector<std::tuple<Int>> data = {{{1, 3}}, {{5, 7}}};
 
     auto generated = data
@@ -83,11 +82,8 @@ BOOST_AUTO_TEST_CASE(test_mutable)
         })
       | ranges::to_vector;
 
-    std::vector<std::tuple<Int>> desired = {{{0, 1}}, {{0, 1}}};
+    std::vector<std::tuple<Int>> desired = {{{0, 1}}, {{2, 3}}};
     test_ranges_equal(generated, desired);
-#else
-    BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
-#endif
 }
 
 BOOST_AUTO_TEST_CASE(test_two_to_one)
@@ -156,7 +152,6 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only)
 
 BOOST_AUTO_TEST_CASE(test_dim2_move_only_mutable)
 {
-#ifdef CXTREAM_MUTABLE_LAMBDA
     auto data = generate_move_only_data();
 
     auto rng = data
@@ -169,9 +164,6 @@ BOOST_AUTO_TEST_CASE(test_dim2_move_only_mutable)
       | unique_vec_to_int_vec();
 
     std::vector<std::vector<std::vector<int>>> generated = unpack(rng, from<IntVec>, dim<0>);
-    std::vector<std::vector<std::vector<int>>> desired = {{{4, 5}, {4, 5}}, {{4, 5}}};
+    std::vector<std::vector<std::vector<int>>> desired = {{{4, 5}, {6, 7}}, {{8, 9}}};
     BOOST_CHECK(generated == desired);
-#else
-    BOOST_TEST_MESSAGE("Cxtream does not support mutable lambdas in this compiler version.");
-#endif
 }

--- a/test/core/utility/tuple.cpp
+++ b/test/core/utility/tuple.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(test_tuple_index_view)
 {
     auto t1 = std::make_tuple(0, 5., 'c');
     auto t2 = tuple_index_view<1, 0>(t1);
-    auto t3 = tuple_index_view<2, 0>(t1);
+    auto t3 = tuple_index_view(t1, std::index_sequence<2, 0>{});
     static_assert(std::is_same<std::tuple<char&, int&>, decltype(t3)>{});
     BOOST_TEST(t2 == std::make_tuple(5., 0));
     BOOST_TEST(t2 == std::make_tuple(5., 0));


### PR DESCRIPTION
- Reimplement `stream::for_each` and `stream::filter` using `stream::transform` to avoid code duplication.
- Propagate types into transformation functions to reduce the number of templates and lambdas and allow for better compile time assertions (yet to be done, see #25). This actually makes the code longer, but easier to read for the compiler.
- Perform type erasure after each transformer to reduce template size in long streams (trade-off is a negligible runtime overhead).

Also:
- Add `column_base::batch_type` and `column_base::example_type` member types ( @petrbel 's request).
- Allow mutable functions in all transformers even on older compilers.

**This is basically a reimplementation of the whole `stream::` namespace, so use with caution.**